### PR TITLE
Fix unit tests

### DIFF
--- a/lib/data/__tests__/assets.test.ts
+++ b/lib/data/__tests__/assets.test.ts
@@ -124,8 +124,8 @@ describe('fetchAssets', () => {
     await fetchPromise
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://rest.coincap.io/v3/assets?limit=19&offset=0&apiKey=test-api-key',
-      { next: { revalidate: 60 } }
+      'https://rest.coincap.io/v3/assets?limit=19&offset=0',
+      { next: { revalidate: 60 }, headers: { Authorization: 'Bearer test-api-key' } }
     )
   })
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,15 +8,11 @@ const EnvSchema = z.object({
 
 type Env = z.infer<typeof EnvSchema>;
 
-let cached: Env | null = null;
-
 export function getEnv(): Env {
-  if (cached) return cached;
   const parsed = EnvSchema.safeParse(process.env);
   if (!parsed.success) {
     console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
     throw new Error('Invalid environment configuration');
   }
-  cached = parsed.data;
-  return cached;
+  return parsed.data;
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 const EnvSchema = z.object({
   // example: "NEXT_PUBLIC_API_URL": z.string().url().optional(),
   COINCAP_API_KEY: z.string().optional(),
+  COINCAP_BASE_URL: z.string().url().optional(),
 });
 
 type Env = z.infer<typeof EnvSchema>;


### PR DESCRIPTION
Update asset fetching test to assert Authorization header and remove environment variable caching to ensure test-set env updates are respected.

The `assets.test.ts` was failing because the `apiKey` was being sent via an `Authorization: Bearer <API_KEY>` header, but the test was expecting it as an `apiKey` query parameter. Additionally, the environment variable caching in `src/lib/env.ts` prevented test-specific environment variable changes from being picked up, leading to inconsistent test results.

---
<a href="https://cursor.com/background-agent?bcId=bc-c965f707-0a75-444e-b836-4630e37b261c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c965f707-0a75-444e-b836-4630e37b261c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

