### PR TITLE
Redesign market data card with bento grid (#26)

### DIFF
--- a/app/details/[symbol]/page.tsx
+++ b/app/details/[symbol]/page.tsx
@@ -47,7 +47,7 @@ export default async function SymbolDetailsPage({ params }: SymbolDetailsPagePro
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-start px-12 pb-8 pt-24">
-      <div className="w-full max-w-4xl mx-auto space-y-6">
+      <div className="w-full max-w-7xl mx-auto space-y-6">
         {/* Header Section */}
         <Card className="glassmorphic">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
@@ -65,31 +65,34 @@ export default async function SymbolDetailsPage({ params }: SymbolDetailsPagePro
           </CardHeader>
         </Card>
 
-        {/* Price Section */}
-        <Card className="glassmorphic">
-          <CardHeader>
-            <CardTitle>Price Information</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className={`flex items-center justify-between ${textColorClass}`}>
-              <span className={`text-4xl font-bold ${glowClass}`}>
-                ${formatNumber(asset.priceUsd)}
-              </span>
-              <span className={`text-xl ${glowClass}`}>
-                {formatPercent(asset.changePercent24Hr)}
-              </span>
-            </div>
-            <div className="w-full">
-              <CryptoSparkline symbol={asset.symbol} />
-            </div>
-          </CardContent>
-        </Card>
+        {/* Price & Market Data Bento Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+          {/* Price Section */}
+          <Card className="glassmorphic">
+            <CardHeader>
+              <CardTitle>Price Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className={`flex items-center justify-between ${textColorClass}`}>
+                <span className={`text-4xl font-bold ${glowClass}`}>
+                  ${formatNumber(asset.priceUsd)}
+                </span>
+                <span className={`text-xl ${glowClass}`}>
+                  {formatPercent(asset.changePercent24Hr)}
+                </span>
+              </div>
+              <div className="w-full">
+                <CryptoSparkline symbol={asset.symbol} />
+              </div>
+            </CardContent>
+          </Card>
 
-        {/* Market Data Section */}
-        {/** Using mock MarketData via ports/adapters; server component by default */}
-        <Suspense fallback={<ShimmerCard />}>
-          <MarketDataCard symbol={asset.symbol} />
-        </Suspense>
+          {/* Market Data Section */}
+          {/** Using mock MarketData via ports/adapters; server component by default */}
+          <Suspense fallback={<ShimmerCard />}>
+            <MarketDataCard symbol={asset.symbol} />
+          </Suspense>
+        </div>
 
         {/* AI Analysis Section */}
         <Card className="glassmorphic">

--- a/components/crypto/card/market-data-card.tsx
+++ b/components/crypto/card/market-data-card.tsx
@@ -1,6 +1,7 @@
 import { prettifyNumber, formatNumber } from '@/lib/utils/numbers';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { fetchMarketData } from '@/lib/data/marketData';
+import { CircleDollarSign, Coins, LineChart, PieChart } from 'lucide-react';
 
 type MarketDataCardProps = {
   symbol: string;
@@ -15,34 +16,59 @@ export default async function MarketDataCard({ symbol }: MarketDataCardProps) {
   const vwap = `$${formatNumber(md.vwap24hUsd)}`;
   const dominance = `${md.dominancePercent.toFixed(0)}%`;
 
+  const dataItems = [
+    {
+      icon: CircleDollarSign,
+      label: 'Market Cap',
+      value: marketCap,
+    },
+    {
+      icon: Coins,
+      label: 'Circulating',
+      value: circulating,
+    },
+    {
+      icon: Coins,
+      label: 'Max Supply',
+      value: maxSupply,
+    },
+    {
+      icon: LineChart,
+      label: 'VWAP (24h)',
+      value: vwap,
+    },
+    {
+      icon: PieChart,
+      label: 'Dominance',
+      value: dominance,
+    },
+  ];
+
   return (
     <Card className="glassmorphic">
       <CardHeader>
         <CardTitle>Market Data</CardTitle>
       </CardHeader>
       <CardContent>
-        <ul className="grid grid-cols-1 gap-3 text-sm md:text-base">
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">Market Cap</span>
-            <span className="font-semibold tabular-nums">{marketCap}</span>
-          </li>
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">Circulating</span>
-            <span className="font-semibold tabular-nums">{circulating}</span>
-          </li>
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">Max Supply</span>
-            <span className="font-semibold tabular-nums">{maxSupply}</span>
-          </li>
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">VWAP (24h)</span>
-            <span className="font-semibold tabular-nums">{vwap}</span>
-          </li>
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">Dominance</span>
-            <span className="font-semibold tabular-nums">{dominance}</span>
-          </li>
-        </ul>
+        <div className="grid grid-cols-1 gap-4">
+          {dataItems.map((item, index) => {
+            const IconComponent = item.icon;
+            return (
+              <div
+                key={index}
+                className="flex items-center justify-between gap-3"
+              >
+                <div className="flex items-center gap-3">
+                  <IconComponent className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">{item.label}</span>
+                </div>
+                <span className="text-base md:text-lg lg:text-xl font-semibold tabular-nums text-right">
+                  {item.value}
+                </span>
+              </div>
+            );
+          })}
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
* Refactor: Improve market data card layout and add icons

This commit restructures the market data card to use a grid layout and incorporates icons for each data point, enhancing visual clarity and organization.



* Refactor: Update market data card styling



* Refactor: Remove unnecessary background styling from market data card



* Refactor: Remove unnecessary div for icon in MarketDataCard



* Refactor: Adjust grid gap for market data card



* Refactor: Organize price and market data into a bento grid



* Refactor: Adjust layout and grid for better responsiveness



---------