### PR TITLE
Implement trading activity card with bento grid

### DIFF
--- a/app/details/[symbol]/__tests__/page.test.tsx
+++ b/app/details/[symbol]/__tests__/page.test.tsx
@@ -231,7 +231,7 @@ describe("SymbolDetailsPage", () => {
     render(component);
 
     // Check that all major sections are rendered
-    expect(screen.getAllByTestId("card")).toHaveLength(4); // Header, Price, Market Data, AI Analysis
+    expect(screen.getAllByTestId("card")).toHaveLength(5); // Header, Price, Market Data, Trading Activity, AI Analysis
     expect(screen.getByTestId("crypto-icon")).toBeInTheDocument();
     expect(screen.getByTestId("crypto-sparkline")).toBeInTheDocument();
     expect(screen.getByTestId("button")).toBeInTheDocument();

--- a/app/details/[symbol]/page.tsx
+++ b/app/details/[symbol]/page.tsx
@@ -15,6 +15,7 @@ import { getPriceMovementTextColorClass } from "@/lib/utils/ui-helpers";
 import { Button } from "@/components/ui/button";
 import ShimmerCard from "@/components/ui/shimmer-card";
 import MarketDataCard from "@/components/crypto/card/market-data-card";
+import TradingActivityCard from "@/components/crypto/card/trading-activity-card";
 
 export const dynamic = "force-dynamic";
 
@@ -91,6 +92,12 @@ export default async function SymbolDetailsPage({ params }: SymbolDetailsPagePro
           {/** Using mock MarketData via ports/adapters; server component by default */}
           <Suspense fallback={<ShimmerCard />}>
             <MarketDataCard symbol={asset.symbol} />
+          </Suspense>
+
+          {/* Trading Activity Section */}
+          {/** Using mock TradingActivity via ports/adapters; server component by default */}
+          <Suspense fallback={<ShimmerCard />}>
+            <TradingActivityCard symbol={asset.symbol} />
           </Suspense>
         </div>
 

--- a/components/crypto/card/__tests__/trading-activity-card.test.tsx
+++ b/components/crypto/card/__tests__/trading-activity-card.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import { fetchTradingActivity } from '@/lib/data/tradingActivity';
+import TradingActivityCard from '../trading-activity-card';
+
+// Mock the fetchTradingActivity function
+jest.mock('@/lib/data/tradingActivity');
+
+const mockFetchTradingActivity = fetchTradingActivity as jest.MockedFunction<typeof fetchTradingActivity>;
+
+// Mock data that matches the TradingActivity interface
+const mockTradingActivity = {
+  symbol: 'BTC',
+  volume24hUsd: 22_000_000_000, // $22B
+  liquidityScore: 95,
+  topExchanges: [
+    { name: 'Binance', percentage: 48 },
+    { name: 'Coinbase', percentage: 28 },
+    { name: 'Kraken', percentage: 24 },
+  ],
+  cexDexSplit: {
+    cex: 85,
+    dex: 15,
+  },
+};
+
+describe('TradingActivityCard', () => {
+  beforeEach(() => {
+    mockFetchTradingActivity.mockResolvedValue(mockTradingActivity);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders trading activity data correctly', async () => {
+    const component = await TradingActivityCard({ symbol: 'BTC' });
+    render(component);
+
+    // Check if the card header is rendered
+    expect(screen.getByText('Trading Activity')).toBeInTheDocument();
+
+    // Check if 24h Volume is rendered
+    expect(screen.getByText('24h Volume')).toBeInTheDocument();
+    expect(screen.getByText('$22B')).toBeInTheDocument();
+
+    // Check if Liquidity Score is rendered
+    expect(screen.getByText('Liquidity Score')).toBeInTheDocument();
+    expect(screen.getByText('95')).toBeInTheDocument();
+
+    // Check if Top Exchanges section is rendered
+    expect(screen.getByText('Top Exchanges')).toBeInTheDocument();
+    expect(screen.getByText('Binance')).toBeInTheDocument();
+    expect(screen.getByText('Coinbase')).toBeInTheDocument();
+    expect(screen.getByText('Kraken')).toBeInTheDocument();
+
+    // Check if CEX/DEX Split section is rendered
+    expect(screen.getByText('CEX/DEX Split')).toBeInTheDocument();
+    expect(screen.getByText('85%')).toBeInTheDocument();
+    expect(screen.getByText('15%')).toBeInTheDocument();
+  });
+
+  it('calls fetchTradingActivity with correct symbol', async () => {
+    await TradingActivityCard({ symbol: 'ETH' });
+    
+    expect(mockFetchTradingActivity).toHaveBeenCalledWith('ETH');
+    expect(mockFetchTradingActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders different exchange data correctly', async () => {
+    const mockETHData = {
+      ...mockTradingActivity,
+      symbol: 'ETH',
+      volume24hUsd: 18_500_000_000,
+      liquidityScore: 87,
+      topExchanges: [
+        { name: 'Uniswap', percentage: 42 },
+        { name: 'Binance', percentage: 35 },
+        { name: 'Coinbase', percentage: 23 },
+      ],
+      cexDexSplit: {
+        cex: 60,
+        dex: 40,
+      },
+    };
+
+    mockFetchTradingActivity.mockResolvedValueOnce(mockETHData);
+    const component = await TradingActivityCard({ symbol: 'ETH' });
+    render(component);
+
+    expect(screen.getByText('$19B')).toBeInTheDocument(); // Should use prettifyNumber formatting 
+    expect(screen.getByText('87')).toBeInTheDocument();
+    expect(screen.getByText('Uniswap')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+  });
+
+  it('renders SVG charts', async () => {
+    const component = await TradingActivityCard({ symbol: 'BTC' });
+    const { container } = render(component);
+
+    // Check that SVG elements are present (donut chart and stacked bar)
+    const svgElements = container.querySelectorAll('svg');
+    expect(svgElements.length).toBeGreaterThanOrEqual(6); // Icons (4) + donut chart (1) + stacked bar (1)
+  });
+
+  it('uses correct icons for each metric', async () => {
+    const component = await TradingActivityCard({ symbol: 'BTC' });
+    render(component);
+
+    // The icons are rendered but not easily testable by their visual appearance
+    // We can test that the content structure is correct by checking for the labels
+    expect(screen.getByText('24h Volume')).toBeInTheDocument();
+    expect(screen.getByText('Liquidity Score')).toBeInTheDocument();
+    expect(screen.getByText('Top Exchanges')).toBeInTheDocument();
+    expect(screen.getByText('CEX/DEX Split')).toBeInTheDocument();
+  });
+});

--- a/components/crypto/card/trading-activity-card.tsx
+++ b/components/crypto/card/trading-activity-card.tsx
@@ -7,29 +7,21 @@ type TradingActivityCardProps = {
   symbol: string;
 };
 
-// Server-rendered SVG donut chart with professional styling
+// Server-rendered SVG donut chart
 function DonutChart({ exchanges }: { exchanges: { name: string; percentage: number }[] }) {
-  const radius = 22;
-  const strokeWidth = 6;
-  const size = (radius + strokeWidth) * 2 + 4; // Extra padding for glow
+  const radius = 20;
+  const strokeWidth = 8;
+  const size = (radius + strokeWidth) * 2;
   const circumference = 2 * Math.PI * radius;
-  const id = Math.random().toString(36).substr(2, 9); // Simple ID for server rendering
   
-  // Use chart color variables for better theming
-  const chartColors = [
-    'hsl(var(--chart-1))',
-    'hsl(var(--chart-2))', 
-    'hsl(var(--chart-3))',
-    'hsl(var(--chart-4))',
-    'hsl(var(--chart-5))'
-  ];
-
   let cumulativePercentage = 0;
   const paths = exchanges.map((exchange, index) => {
     const percentage = exchange.percentage / 100;
     const strokeDasharray = `${percentage * circumference} ${circumference}`;
     const strokeDashoffset = -cumulativePercentage * circumference;
     cumulativePercentage += percentage;
+    
+    const colors = ['#3b82f6', '#8b5cf6', '#f59e0b']; // blue, purple, amber
     
     return (
       <circle
@@ -38,156 +30,74 @@ function DonutChart({ exchanges }: { exchanges: { name: string; percentage: numb
         cy={size / 2}
         r={radius}
         fill="none"
-        stroke={chartColors[index] || 'hsl(var(--muted-foreground))'}
+        stroke={colors[index] || '#6b7280'}
         strokeWidth={strokeWidth}
         strokeDasharray={strokeDasharray}
         strokeDashoffset={strokeDashoffset}
         transform={`rotate(-90 ${size / 2} ${size / 2})`}
-        className="opacity-90 transition-opacity duration-300"
-        style={{
-          filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))',
-          strokeLinecap: 'round'
-        }}
+        className="opacity-80"
       />
     );
   });
 
   return (
-    <div className="flex items-center gap-3">
-      <div className="relative">
-        <svg width={size} height={size} className="shrink-0">
-          <defs>
-            {/* Subtle glow effect */}
-            <filter id={`glow-${id}`}>
-              <feGaussianBlur stdDeviation="1" result="coloredBlur"/>
-              <feMerge> 
-                <feMergeNode in="coloredBlur"/>
-                <feMergeNode in="SourceGraphic"/>
-              </feMerge>
-            </filter>
-          </defs>
-          <g filter={`url(#glow-${id})`}>
-            {paths}
-          </g>
-        </svg>
-        {/* Center dot for polish */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="w-1.5 h-1.5 rounded-full bg-foreground/20"></div>
-        </div>
-      </div>
-      <div className="grid grid-cols-1 gap-1 text-xs">
-        {exchanges.map((exchange, index) => (
-          <div key={index} className="flex items-center gap-2 group">
-            <div 
-              className="w-2.5 h-2.5 rounded-full transition-transform duration-200 group-hover:scale-110 shadow-sm"
-              style={{ backgroundColor: chartColors[index] || 'hsl(var(--muted-foreground))' }}
-            />
-            <span className="text-muted-foreground font-medium truncate max-w-16">
-              {exchange.name}
-            </span>
-            <span className="text-foreground font-semibold ml-auto">
-              {exchange.percentage}%
-            </span>
-          </div>
-        ))}
+    <div className="flex items-center gap-2">
+      <svg width={size} height={size} className="shrink-0">
+        {paths}
+      </svg>
+      <div className="grid grid-cols-1 gap-0.5 text-xs text-muted-foreground">
+        {exchanges.map((exchange, index) => {
+          const colors = ['bg-blue-500', 'bg-purple-500', 'bg-amber-500'];
+          return (
+            <div key={index} className="flex items-center gap-1">
+              <div className={`w-2 h-2 rounded-full ${colors[index] || 'bg-gray-500'} opacity-80`} />
+              <span className="truncate max-w-16">{exchange.name}</span>
+              <span>{exchange.percentage}%</span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
 }
 
-// Server-rendered SVG stacked bar chart with gradients and glow
+// Server-rendered SVG stacked bar chart
 function StackedBar({ cex, dex }: { cex: number; dex: number }) {
-  const width = 100;
-  const height = 16;
-  const borderRadius = 8;
+  const width = 80;
+  const height = 12;
   const cexWidth = (cex / 100) * width;
   const dexWidth = (dex / 100) * width;
-  const id = Math.random().toString(36).substr(2, 9);
 
   return (
-    <div className="flex items-center gap-3">
-      <div className="relative">
-        <svg width={width} height={height} className="shrink-0">
-          <defs>
-            {/* CEX gradient */}
-            <linearGradient id={`cex-gradient-${id}`} x1="0%" y1="0%" x2="100%" y2="0%">
-              <stop offset="0%" stopColor="hsl(var(--chart-1))" stopOpacity="0.9" />
-              <stop offset="100%" stopColor="hsl(var(--chart-1))" stopOpacity="0.7" />
-            </linearGradient>
-            {/* DEX gradient */}
-            <linearGradient id={`dex-gradient-${id}`} x1="0%" y1="0%" x2="100%" y2="0%">
-              <stop offset="0%" stopColor="hsl(var(--chart-2))" stopOpacity="0.9" />
-              <stop offset="100%" stopColor="hsl(var(--chart-2))" stopOpacity="0.7" />
-            </linearGradient>
-            {/* Subtle shadow */}
-            <filter id={`bar-shadow-${id}`}>
-              <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="black" floodOpacity="0.15"/>
-            </filter>
-          </defs>
-          
-          {/* Background track */}
-          <rect
-            x={0}
-            y={0}
-            width={width}
-            height={height}
-            fill="hsl(var(--muted))"
-            rx={borderRadius}
-            className="opacity-30"
-          />
-          
-          {/* CEX bar */}
-          <rect
-            x={0}
-            y={0}
-            width={cexWidth}
-            height={height}
-            fill={`url(#cex-gradient-${id})`}
-            rx={borderRadius}
-            filter={`url(#bar-shadow-${id})`}
-            className="transition-all duration-300"
-          />
-          
-          {/* DEX bar */}
-          <rect
-            x={cexWidth}
-            y={0}
-            width={dexWidth}
-            height={height}
-            fill={`url(#dex-gradient-${id})`}
-            rx={borderRadius}
-            filter={`url(#bar-shadow-${id})`}
-            className="transition-all duration-300"
-          />
-          
-          {/* Subtle highlight on top */}
-          <rect
-            x={0}
-            y={0}
-            width={width}
-            height={2}
-            fill="rgba(255,255,255,0.2)"
-            rx={borderRadius}
-          />
-        </svg>
-      </div>
-      
-      <div className="flex items-center gap-3 text-xs">
-        <div className="flex items-center gap-1.5 group">
-          <div 
-            className="w-2.5 h-2.5 rounded-full shadow-sm transition-transform duration-200 group-hover:scale-110"
-            style={{ backgroundColor: 'hsl(var(--chart-1))' }}
-          />
-          <span className="text-muted-foreground font-medium">CEX</span>
-          <span className="text-foreground font-semibold">{cex}%</span>
+    <div className="flex items-center gap-2">
+      <svg width={width} height={height} className="shrink-0">
+        <rect
+          x={0}
+          y={0}
+          width={cexWidth}
+          height={height}
+          fill="#3b82f6"
+          className="opacity-80"
+          rx={2}
+        />
+        <rect
+          x={cexWidth}
+          y={0}
+          width={dexWidth}
+          height={height}
+          fill="#8b5cf6"
+          className="opacity-80"
+          rx={2}
+        />
+      </svg>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-blue-500 opacity-80" />
+          <span>{cex}%</span>
         </div>
-        <div className="flex items-center gap-1.5 group">
-          <div 
-            className="w-2.5 h-2.5 rounded-full shadow-sm transition-transform duration-200 group-hover:scale-110"
-            style={{ backgroundColor: 'hsl(var(--chart-2))' }}
-          />
-          <span className="text-muted-foreground font-medium">DEX</span>
-          <span className="text-foreground font-semibold">{dex}%</span>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-purple-500 opacity-80" />
+          <span>{dex}%</span>
         </div>
       </div>
     </div>
@@ -205,57 +115,45 @@ export default async function TradingActivityCard({ symbol }: TradingActivityCar
         <CardTitle>Trading Activity</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-1 gap-5">
+        <div className="grid grid-cols-1 gap-4">
           {/* 24h Volume */}
-          <div className="flex items-center justify-between gap-3 group">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <BarChart3 className="h-4 w-4 text-chart-1 transition-colors duration-200" />
-              <span className="text-sm text-muted-foreground font-medium">24h Volume</span>
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">24h Volume</span>
             </div>
-            <span className="text-base md:text-lg lg:text-xl font-bold tabular-nums text-right text-foreground group-hover:text-chart-1 transition-colors duration-200">
+            <span className="text-base md:text-lg lg:text-xl font-semibold tabular-nums text-right">
               {volume24h}
             </span>
           </div>
 
           {/* Liquidity Score */}
-          <div className="flex items-center justify-between gap-3 group">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <Droplet className="h-4 w-4 text-chart-4 transition-colors duration-200" />
-              <span className="text-sm text-muted-foreground font-medium">Liquidity Score</span>
+              <Droplet className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Liquidity Score</span>
             </div>
-            <div className="relative">
-              <div className="rounded-full bg-gradient-to-r from-chart-3/20 to-chart-1/20 px-3 py-1 border border-chart-1/30 shadow-sm">
-                <span className="text-sm font-bold tabular-nums text-foreground">
-                  {ta.liquidityScore}
-                </span>
-              </div>
-              {/* Subtle glow for high scores */}
-              {ta.liquidityScore > 80 && (
-                <div className="absolute inset-0 rounded-full bg-chart-1/10 blur-sm -z-10"></div>
-              )}
+            <div className="rounded-md bg-muted/40 px-2 py-0.5 font-semibold text-sm">
+              {ta.liquidityScore}
             </div>
           </div>
 
           {/* Top Exchanges */}
-          <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <PieChart className="h-4 w-4 text-chart-2 transition-colors duration-200" />
-              <span className="text-sm text-muted-foreground font-medium">Top Exchanges</span>
+              <PieChart className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Top Exchanges</span>
             </div>
-            <div className="pl-7">
-              <DonutChart exchanges={ta.topExchanges} />
-            </div>
+            <DonutChart exchanges={ta.topExchanges} />
           </div>
 
           {/* CEX/DEX Split */}
-          <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <GitFork className="h-4 w-4 text-chart-3 transition-colors duration-200" />
-              <span className="text-sm text-muted-foreground font-medium">CEX/DEX Split</span>
+              <GitFork className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">CEX/DEX Split</span>
             </div>
-            <div className="pl-7">
-              <StackedBar cex={ta.cexDexSplit.cex} dex={ta.cexDexSplit.dex} />
-            </div>
+            <StackedBar cex={ta.cexDexSplit.cex} dex={ta.cexDexSplit.dex} />
           </div>
         </div>
       </CardContent>

--- a/components/crypto/card/trading-activity-card.tsx
+++ b/components/crypto/card/trading-activity-card.tsx
@@ -115,7 +115,7 @@ export default async function TradingActivityCard({ symbol }: TradingActivityCar
         <CardTitle>Trading Activity</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4">
           {/* 24h Volume */}
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">

--- a/components/crypto/card/trading-activity-card.tsx
+++ b/components/crypto/card/trading-activity-card.tsx
@@ -7,21 +7,29 @@ type TradingActivityCardProps = {
   symbol: string;
 };
 
-// Server-rendered SVG donut chart
+// Server-rendered SVG donut chart with professional styling
 function DonutChart({ exchanges }: { exchanges: { name: string; percentage: number }[] }) {
-  const radius = 20;
-  const strokeWidth = 8;
-  const size = (radius + strokeWidth) * 2;
+  const radius = 22;
+  const strokeWidth = 6;
+  const size = (radius + strokeWidth) * 2 + 4; // Extra padding for glow
   const circumference = 2 * Math.PI * radius;
+  const id = Math.random().toString(36).substr(2, 9); // Simple ID for server rendering
   
+  // Use chart color variables for better theming
+  const chartColors = [
+    'hsl(var(--chart-1))',
+    'hsl(var(--chart-2))', 
+    'hsl(var(--chart-3))',
+    'hsl(var(--chart-4))',
+    'hsl(var(--chart-5))'
+  ];
+
   let cumulativePercentage = 0;
   const paths = exchanges.map((exchange, index) => {
     const percentage = exchange.percentage / 100;
     const strokeDasharray = `${percentage * circumference} ${circumference}`;
     const strokeDashoffset = -cumulativePercentage * circumference;
     cumulativePercentage += percentage;
-    
-    const colors = ['#3b82f6', '#8b5cf6', '#f59e0b']; // blue, purple, amber
     
     return (
       <circle
@@ -30,74 +38,156 @@ function DonutChart({ exchanges }: { exchanges: { name: string; percentage: numb
         cy={size / 2}
         r={radius}
         fill="none"
-        stroke={colors[index] || '#6b7280'}
+        stroke={chartColors[index] || 'hsl(var(--muted-foreground))'}
         strokeWidth={strokeWidth}
         strokeDasharray={strokeDasharray}
         strokeDashoffset={strokeDashoffset}
         transform={`rotate(-90 ${size / 2} ${size / 2})`}
-        className="opacity-80"
+        className="opacity-90 transition-opacity duration-300"
+        style={{
+          filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))',
+          strokeLinecap: 'round'
+        }}
       />
     );
   });
 
   return (
-    <div className="flex items-center gap-2">
-      <svg width={size} height={size} className="shrink-0">
-        {paths}
-      </svg>
-      <div className="grid grid-cols-1 gap-0.5 text-xs text-muted-foreground">
-        {exchanges.map((exchange, index) => {
-          const colors = ['bg-blue-500', 'bg-purple-500', 'bg-amber-500'];
-          return (
-            <div key={index} className="flex items-center gap-1">
-              <div className={`w-2 h-2 rounded-full ${colors[index] || 'bg-gray-500'} opacity-80`} />
-              <span className="truncate max-w-16">{exchange.name}</span>
-              <span>{exchange.percentage}%</span>
-            </div>
-          );
-        })}
+    <div className="flex items-center gap-3">
+      <div className="relative">
+        <svg width={size} height={size} className="shrink-0">
+          <defs>
+            {/* Subtle glow effect */}
+            <filter id={`glow-${id}`}>
+              <feGaussianBlur stdDeviation="1" result="coloredBlur"/>
+              <feMerge> 
+                <feMergeNode in="coloredBlur"/>
+                <feMergeNode in="SourceGraphic"/>
+              </feMerge>
+            </filter>
+          </defs>
+          <g filter={`url(#glow-${id})`}>
+            {paths}
+          </g>
+        </svg>
+        {/* Center dot for polish */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-1.5 h-1.5 rounded-full bg-foreground/20"></div>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-1 text-xs">
+        {exchanges.map((exchange, index) => (
+          <div key={index} className="flex items-center gap-2 group">
+            <div 
+              className="w-2.5 h-2.5 rounded-full transition-transform duration-200 group-hover:scale-110 shadow-sm"
+              style={{ backgroundColor: chartColors[index] || 'hsl(var(--muted-foreground))' }}
+            />
+            <span className="text-muted-foreground font-medium truncate max-w-16">
+              {exchange.name}
+            </span>
+            <span className="text-foreground font-semibold ml-auto">
+              {exchange.percentage}%
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );
 }
 
-// Server-rendered SVG stacked bar chart
+// Server-rendered SVG stacked bar chart with gradients and glow
 function StackedBar({ cex, dex }: { cex: number; dex: number }) {
-  const width = 80;
-  const height = 12;
+  const width = 100;
+  const height = 16;
+  const borderRadius = 8;
   const cexWidth = (cex / 100) * width;
   const dexWidth = (dex / 100) * width;
+  const id = Math.random().toString(36).substr(2, 9);
 
   return (
-    <div className="flex items-center gap-2">
-      <svg width={width} height={height} className="shrink-0">
-        <rect
-          x={0}
-          y={0}
-          width={cexWidth}
-          height={height}
-          fill="#3b82f6"
-          className="opacity-80"
-          rx={2}
-        />
-        <rect
-          x={cexWidth}
-          y={0}
-          width={dexWidth}
-          height={height}
-          fill="#8b5cf6"
-          className="opacity-80"
-          rx={2}
-        />
-      </svg>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <div className="flex items-center gap-1">
-          <div className="w-2 h-2 rounded-full bg-blue-500 opacity-80" />
-          <span>{cex}%</span>
+    <div className="flex items-center gap-3">
+      <div className="relative">
+        <svg width={width} height={height} className="shrink-0">
+          <defs>
+            {/* CEX gradient */}
+            <linearGradient id={`cex-gradient-${id}`} x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="hsl(var(--chart-1))" stopOpacity="0.9" />
+              <stop offset="100%" stopColor="hsl(var(--chart-1))" stopOpacity="0.7" />
+            </linearGradient>
+            {/* DEX gradient */}
+            <linearGradient id={`dex-gradient-${id}`} x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="hsl(var(--chart-2))" stopOpacity="0.9" />
+              <stop offset="100%" stopColor="hsl(var(--chart-2))" stopOpacity="0.7" />
+            </linearGradient>
+            {/* Subtle shadow */}
+            <filter id={`bar-shadow-${id}`}>
+              <feDropShadow dx="0" dy="1" stdDeviation="1" floodColor="black" floodOpacity="0.15"/>
+            </filter>
+          </defs>
+          
+          {/* Background track */}
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={height}
+            fill="hsl(var(--muted))"
+            rx={borderRadius}
+            className="opacity-30"
+          />
+          
+          {/* CEX bar */}
+          <rect
+            x={0}
+            y={0}
+            width={cexWidth}
+            height={height}
+            fill={`url(#cex-gradient-${id})`}
+            rx={borderRadius}
+            filter={`url(#bar-shadow-${id})`}
+            className="transition-all duration-300"
+          />
+          
+          {/* DEX bar */}
+          <rect
+            x={cexWidth}
+            y={0}
+            width={dexWidth}
+            height={height}
+            fill={`url(#dex-gradient-${id})`}
+            rx={borderRadius}
+            filter={`url(#bar-shadow-${id})`}
+            className="transition-all duration-300"
+          />
+          
+          {/* Subtle highlight on top */}
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={2}
+            fill="rgba(255,255,255,0.2)"
+            rx={borderRadius}
+          />
+        </svg>
+      </div>
+      
+      <div className="flex items-center gap-3 text-xs">
+        <div className="flex items-center gap-1.5 group">
+          <div 
+            className="w-2.5 h-2.5 rounded-full shadow-sm transition-transform duration-200 group-hover:scale-110"
+            style={{ backgroundColor: 'hsl(var(--chart-1))' }}
+          />
+          <span className="text-muted-foreground font-medium">CEX</span>
+          <span className="text-foreground font-semibold">{cex}%</span>
         </div>
-        <div className="flex items-center gap-1">
-          <div className="w-2 h-2 rounded-full bg-purple-500 opacity-80" />
-          <span>{dex}%</span>
+        <div className="flex items-center gap-1.5 group">
+          <div 
+            className="w-2.5 h-2.5 rounded-full shadow-sm transition-transform duration-200 group-hover:scale-110"
+            style={{ backgroundColor: 'hsl(var(--chart-2))' }}
+          />
+          <span className="text-muted-foreground font-medium">DEX</span>
+          <span className="text-foreground font-semibold">{dex}%</span>
         </div>
       </div>
     </div>
@@ -115,45 +205,57 @@ export default async function TradingActivityCard({ symbol }: TradingActivityCar
         <CardTitle>Trading Activity</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-1 gap-4">
+        <div className="grid grid-cols-1 gap-5">
           {/* 24h Volume */}
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-3 group">
             <div className="flex items-center gap-3">
-              <BarChart3 className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">24h Volume</span>
+              <BarChart3 className="h-4 w-4 text-chart-1 transition-colors duration-200" />
+              <span className="text-sm text-muted-foreground font-medium">24h Volume</span>
             </div>
-            <span className="text-base md:text-lg lg:text-xl font-semibold tabular-nums text-right">
+            <span className="text-base md:text-lg lg:text-xl font-bold tabular-nums text-right text-foreground group-hover:text-chart-1 transition-colors duration-200">
               {volume24h}
             </span>
           </div>
 
           {/* Liquidity Score */}
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-3 group">
             <div className="flex items-center gap-3">
-              <Droplet className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">Liquidity Score</span>
+              <Droplet className="h-4 w-4 text-chart-4 transition-colors duration-200" />
+              <span className="text-sm text-muted-foreground font-medium">Liquidity Score</span>
             </div>
-            <div className="rounded-md bg-muted/40 px-2 py-0.5 font-semibold text-sm">
-              {ta.liquidityScore}
+            <div className="relative">
+              <div className="rounded-full bg-gradient-to-r from-chart-3/20 to-chart-1/20 px-3 py-1 border border-chart-1/30 shadow-sm">
+                <span className="text-sm font-bold tabular-nums text-foreground">
+                  {ta.liquidityScore}
+                </span>
+              </div>
+              {/* Subtle glow for high scores */}
+              {ta.liquidityScore > 80 && (
+                <div className="absolute inset-0 rounded-full bg-chart-1/10 blur-sm -z-10"></div>
+              )}
             </div>
           </div>
 
           {/* Top Exchanges */}
-          <div className="flex items-center justify-between gap-3">
+          <div className="space-y-3">
             <div className="flex items-center gap-3">
-              <PieChart className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">Top Exchanges</span>
+              <PieChart className="h-4 w-4 text-chart-2 transition-colors duration-200" />
+              <span className="text-sm text-muted-foreground font-medium">Top Exchanges</span>
             </div>
-            <DonutChart exchanges={ta.topExchanges} />
+            <div className="pl-7">
+              <DonutChart exchanges={ta.topExchanges} />
+            </div>
           </div>
 
           {/* CEX/DEX Split */}
-          <div className="flex items-center justify-between gap-3">
+          <div className="space-y-3">
             <div className="flex items-center gap-3">
-              <GitFork className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">CEX/DEX Split</span>
+              <GitFork className="h-4 w-4 text-chart-3 transition-colors duration-200" />
+              <span className="text-sm text-muted-foreground font-medium">CEX/DEX Split</span>
             </div>
-            <StackedBar cex={ta.cexDexSplit.cex} dex={ta.cexDexSplit.dex} />
+            <div className="pl-7">
+              <StackedBar cex={ta.cexDexSplit.cex} dex={ta.cexDexSplit.dex} />
+            </div>
           </div>
         </div>
       </CardContent>

--- a/components/crypto/card/trading-activity-card.tsx
+++ b/components/crypto/card/trading-activity-card.tsx
@@ -1,0 +1,162 @@
+import { prettifyNumber } from '@/lib/utils/numbers';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { fetchTradingActivity } from '@/lib/data/tradingActivity';
+import { BarChart3, Droplet, PieChart, GitFork } from 'lucide-react';
+
+type TradingActivityCardProps = {
+  symbol: string;
+};
+
+// Server-rendered SVG donut chart
+function DonutChart({ exchanges }: { exchanges: { name: string; percentage: number }[] }) {
+  const radius = 20;
+  const strokeWidth = 8;
+  const size = (radius + strokeWidth) * 2;
+  const circumference = 2 * Math.PI * radius;
+  
+  let cumulativePercentage = 0;
+  const paths = exchanges.map((exchange, index) => {
+    const percentage = exchange.percentage / 100;
+    const strokeDasharray = `${percentage * circumference} ${circumference}`;
+    const strokeDashoffset = -cumulativePercentage * circumference;
+    cumulativePercentage += percentage;
+    
+    const colors = ['#3b82f6', '#8b5cf6', '#f59e0b']; // blue, purple, amber
+    
+    return (
+      <circle
+        key={index}
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke={colors[index] || '#6b7280'}
+        strokeWidth={strokeWidth}
+        strokeDasharray={strokeDasharray}
+        strokeDashoffset={strokeDashoffset}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        className="opacity-80"
+      />
+    );
+  });
+
+  return (
+    <div className="flex items-center gap-2">
+      <svg width={size} height={size} className="shrink-0">
+        {paths}
+      </svg>
+      <div className="grid grid-cols-1 gap-0.5 text-xs text-muted-foreground">
+        {exchanges.map((exchange, index) => {
+          const colors = ['bg-blue-500', 'bg-purple-500', 'bg-amber-500'];
+          return (
+            <div key={index} className="flex items-center gap-1">
+              <div className={`w-2 h-2 rounded-full ${colors[index] || 'bg-gray-500'} opacity-80`} />
+              <span className="truncate max-w-16">{exchange.name}</span>
+              <span>{exchange.percentage}%</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Server-rendered SVG stacked bar chart
+function StackedBar({ cex, dex }: { cex: number; dex: number }) {
+  const width = 80;
+  const height = 12;
+  const cexWidth = (cex / 100) * width;
+  const dexWidth = (dex / 100) * width;
+
+  return (
+    <div className="flex items-center gap-2">
+      <svg width={width} height={height} className="shrink-0">
+        <rect
+          x={0}
+          y={0}
+          width={cexWidth}
+          height={height}
+          fill="#3b82f6"
+          className="opacity-80"
+          rx={2}
+        />
+        <rect
+          x={cexWidth}
+          y={0}
+          width={dexWidth}
+          height={height}
+          fill="#8b5cf6"
+          className="opacity-80"
+          rx={2}
+        />
+      </svg>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-blue-500 opacity-80" />
+          <span>{cex}%</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-purple-500 opacity-80" />
+          <span>{dex}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default async function TradingActivityCard({ symbol }: TradingActivityCardProps) {
+  const ta = await fetchTradingActivity(symbol);
+
+  const volume24h = `$${prettifyNumber(ta.volume24hUsd)}`;
+
+  return (
+    <Card className="glassmorphic">
+      <CardHeader>
+        <CardTitle>Trading Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* 24h Volume */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">24h Volume</span>
+            </div>
+            <span className="text-base md:text-lg lg:text-xl font-semibold tabular-nums text-right">
+              {volume24h}
+            </span>
+          </div>
+
+          {/* Liquidity Score */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <Droplet className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Liquidity Score</span>
+            </div>
+            <div className="rounded-md bg-muted/40 px-2 py-0.5 font-semibold text-sm">
+              {ta.liquidityScore}
+            </div>
+          </div>
+
+          {/* Top Exchanges */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <PieChart className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Top Exchanges</span>
+            </div>
+            <DonutChart exchanges={ta.topExchanges} />
+          </div>
+
+          {/* CEX/DEX Split */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <GitFork className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">CEX/DEX Split</span>
+            </div>
+            <StackedBar cex={ta.cexDexSplit.cex} dex={ta.cexDexSplit.dex} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/data/tradingActivity.ts
+++ b/lib/data/tradingActivity.ts
@@ -1,0 +1,9 @@
+import { TradingActivity } from '@/domain/tradingActivity';
+import { getTradingActivity as _getTradingActivity } from '@/usecases/getTradingActivity';
+import { MockTradingActivityAdapter } from '@/adapters/mock/MockTradingActivityAdapter';
+
+export type { TradingActivity };
+
+export async function fetchTradingActivity(symbol: string): Promise<TradingActivity> {
+  return _getTradingActivity({ tradingActivity: new MockTradingActivityAdapter() }, symbol);
+}

--- a/src/adapters/mock/MockTradingActivityAdapter.ts
+++ b/src/adapters/mock/MockTradingActivityAdapter.ts
@@ -1,0 +1,62 @@
+import { TradingActivity } from '@/domain/tradingActivity';
+import { TradingActivityPort } from '@/ports/TradingActivityPort';
+
+/**
+ * Mock adapter returning deterministic TradingActivity for UI development.
+ */
+export class MockTradingActivityAdapter implements TradingActivityPort {
+  async getBySymbol(symbol: string): Promise<TradingActivity> {
+    const upper = symbol.toUpperCase();
+    
+    // Provide some hardcoded values per symbol with reasonable defaults
+    if (upper === 'BTC') {
+      return {
+        symbol: 'BTC',
+        volume24hUsd: 22_000_000_000, // $22B
+        liquidityScore: 95,
+        topExchanges: [
+          { name: 'Binance', percentage: 48 },
+          { name: 'Coinbase', percentage: 28 },
+          { name: 'Kraken', percentage: 24 },
+        ],
+        cexDexSplit: {
+          cex: 85,
+          dex: 15,
+        },
+      };
+    }
+
+    if (upper === 'ETH') {
+      return {
+        symbol: 'ETH',
+        volume24hUsd: 18_500_000_000, // $18.5B
+        liquidityScore: 87,
+        topExchanges: [
+          { name: 'Uniswap', percentage: 42 },
+          { name: 'Binance', percentage: 35 },
+          { name: 'Coinbase', percentage: 23 },
+        ],
+        cexDexSplit: {
+          cex: 60,
+          dex: 40,
+        },
+      };
+    }
+
+    // Fallback generic mock
+    return {
+      symbol: upper,
+      volume24hUsd: 1_200_000_000, // $1.2B
+      liquidityScore: 72,
+      topExchanges: [
+        { name: 'Binance', percentage: 52 },
+        { name: 'Gate.io', percentage: 31 },
+        { name: 'KuCoin', percentage: 17 },
+      ],
+      cexDexSplit: {
+        cex: 78,
+        dex: 22,
+      },
+    };
+  }
+}

--- a/src/domain/tradingActivity.ts
+++ b/src/domain/tradingActivity.ts
@@ -1,0 +1,15 @@
+export interface TradingActivity {
+  symbol: string;
+  volume24hUsd: number;
+  liquidityScore: number; // 0-100
+  topExchanges: ExchangeShare[];
+  cexDexSplit: {
+    cex: number; // percentage 0-100
+    dex: number; // percentage 0-100
+  };
+}
+
+export interface ExchangeShare {
+  name: string;
+  percentage: number; // percentage 0-100
+}

--- a/src/ports/TradingActivityPort.ts
+++ b/src/ports/TradingActivityPort.ts
@@ -1,0 +1,5 @@
+import { TradingActivity } from '@/domain/tradingActivity';
+
+export interface TradingActivityPort {
+  getBySymbol(symbol: string): Promise<TradingActivity>;
+}

--- a/src/usecases/getTradingActivity.ts
+++ b/src/usecases/getTradingActivity.ts
@@ -1,0 +1,13 @@
+import { TradingActivity } from '@/domain/tradingActivity';
+import { TradingActivityPort } from '@/ports/TradingActivityPort';
+
+type Dependencies = {
+  tradingActivity: TradingActivityPort;
+};
+
+export async function getTradingActivity(
+  deps: Dependencies,
+  symbol: string
+): Promise<TradingActivity> {
+  return deps.tradingActivity.getBySymbol(symbol);
+}


### PR DESCRIPTION
Add the Trading Activity card to the symbol details page, displaying key metrics in a responsive bento grid with server-rendered SVG charts and mock data.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9f3e066-4330-490c-8f78-91ce3478389c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9f3e066-4330-490c-8f78-91ce3478389c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

