### PR TITLE
fix(L3): remove direct adapter imports from newsTool

### DIFF
--- a/src/adapters/langchain/LangChainAiAdapter.ts
+++ b/src/adapters/langchain/LangChainAiAdapter.ts
@@ -1,11 +1,14 @@
 import { AiAnalysisPort } from "@/ports/AiAnalysisPort";
 import { ChatOpenAI } from "@langchain/openai";
 import { createPriceTools, type PriceTools } from "./tools/priceTools";
-import { getNewsArticlesTool } from "./tools/newsTool";
+import { createNewsTool, type NewsTools } from "./tools/newsTool";
 import { getEnv } from "@/lib/env";
 import { BinanceAdapter } from "@/adapters/binance/BinanceAdapter";
+import { NewsAdapter } from "@/adapters/news/NewsAdapter";
+import { MockNewsAdapter } from "@/adapters/news/MockNewsAdapter";
 import { getPriceHistory, getVWAP } from "@/usecases/getPrices";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
+import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
 
 interface PriceHistoryToolResult {
@@ -29,8 +32,6 @@ interface NewsToolResult {
   symbol?: string;
   count?: number;
   data?: NewsArticle[];
-  source?: 'live' | 'mock';
-  fallback?: boolean;
   message?: string;
 }
 
@@ -131,8 +132,7 @@ function formatNews(result: NewsToolResult): string {
     return "No recent news articles found.";
   }
 
-  const sourceNote = result.source === 'mock' ? " (demo data)" : "";
-  let newsContext = `Recent News${sourceNote}:\n`;
+  let newsContext = `Recent News:\n`;
 
   result.data.slice(0, 5).forEach((article, idx) => {
     const date = new Date(article.publishedAt).toLocaleDateString();
@@ -153,8 +153,9 @@ export class LangChainAiAdapter implements AiAnalysisPort {
   private model: ChatOpenAI;
   private getPriceHistoryTool: PriceTools['getPriceHistoryTool'];
   private getVWAPTool: PriceTools['getVWAPTool'];
+  private getNewsArticlesTool: NewsTools['getNewsArticlesTool'];
 
-  constructor(deps?: { binance?: BinancePort }) {
+  constructor(deps?: { binance?: BinancePort; news?: NewsPort }) {
     const env = getEnv();
 
     if (!env.OPENAI_API_KEY) {
@@ -176,6 +177,10 @@ export class LangChainAiAdapter implements AiAnalysisPort {
     });
     this.getPriceHistoryTool = getPriceHistoryTool;
     this.getVWAPTool = getVWAPTool;
+
+    const newsPort = deps?.news ?? (env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter());
+    const { getNewsArticlesTool } = createNewsTool({ newsPort });
+    this.getNewsArticlesTool = getNewsArticlesTool;
   }
 
   /**
@@ -207,7 +212,7 @@ Do not provide financial advice. Focus on data-driven observations.`;
       const [priceHistoryResult, vwapResult, newsResult] = await Promise.allSettled([
         this.getPriceHistoryTool.invoke({ symbol: binanceSymbol, limit: 14 }),
         this.getVWAPTool.invoke({ symbol: binanceSymbol }),
-        getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: 5 }),
+        this.getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: 5 }),
       ]);
 
       // Parse and format tool results for LLM consumption

--- a/src/adapters/langchain/LangChainAiAdapter.ts
+++ b/src/adapters/langchain/LangChainAiAdapter.ts
@@ -1,11 +1,14 @@
 import { AiAnalysisPort } from "@/ports/AiAnalysisPort";
 import { ChatOpenAI } from "@langchain/openai";
 import { createPriceTools, type PriceTools } from "./tools/priceTools";
-import { getNewsArticlesTool } from "./tools/newsTool";
+import { createNewsTool, type NewsTools } from "./tools/newsTool";
 import { getEnv } from "@/lib/env";
 import { BinanceAdapter } from "@/adapters/binance/BinanceAdapter";
+import { NewsAdapter } from "@/adapters/news/NewsAdapter";
+import { MockNewsAdapter } from "@/adapters/news/MockNewsAdapter";
 import { getPriceHistory, getVWAP } from "@/usecases/getPrices";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
+import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
 
 interface PriceHistoryToolResult {
@@ -153,8 +156,9 @@ export class LangChainAiAdapter implements AiAnalysisPort {
   private model: ChatOpenAI;
   private getPriceHistoryTool: PriceTools['getPriceHistoryTool'];
   private getVWAPTool: PriceTools['getVWAPTool'];
+  private getNewsArticlesTool: NewsTools['getNewsArticlesTool'];
 
-  constructor(deps?: { binance?: BinancePort }) {
+  constructor(deps?: { binance?: BinancePort; news?: NewsPort }) {
     const env = getEnv();
 
     if (!env.OPENAI_API_KEY) {
@@ -176,6 +180,10 @@ export class LangChainAiAdapter implements AiAnalysisPort {
     });
     this.getPriceHistoryTool = getPriceHistoryTool;
     this.getVWAPTool = getVWAPTool;
+
+    const newsPort = deps?.news ?? (env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter());
+    const { getNewsArticlesTool } = createNewsTool({ newsPort });
+    this.getNewsArticlesTool = getNewsArticlesTool;
   }
 
   /**
@@ -207,7 +215,7 @@ Do not provide financial advice. Focus on data-driven observations.`;
       const [priceHistoryResult, vwapResult, newsResult] = await Promise.allSettled([
         this.getPriceHistoryTool.invoke({ symbol: binanceSymbol, limit: 14 }),
         this.getVWAPTool.invoke({ symbol: binanceSymbol }),
-        getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: 5 }),
+        this.getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: 5 }),
       ]);
 
       // Parse and format tool results for LLM consumption

--- a/src/adapters/langchain/tools/__tests__/newsTool.test.ts
+++ b/src/adapters/langchain/tools/__tests__/newsTool.test.ts
@@ -1,0 +1,241 @@
+/** @jest-environment node */
+
+// Mock langchain before any imports
+jest.mock('langchain', () => ({
+  tool: jest.fn((func, config) => ({
+    invoke: func,
+    name: config.name,
+    description: config.description,
+    schema: config.schema,
+  })),
+}));
+
+// Mock zod
+jest.mock('zod', () => ({
+  z: {
+    object: jest.fn(() => ({})),
+    string: jest.fn(() => ({
+      describe: jest.fn(() => ({})),
+    })),
+    number: jest.fn(() => ({
+      min: jest.fn(() => ({
+        max: jest.fn(() => ({
+          optional: jest.fn(() => ({
+            describe: jest.fn(() => ({})),
+          })),
+        })),
+      })),
+    })),
+  },
+}));
+
+import { createNewsTool } from '../newsTool';
+import type { NewsPort } from '@/ports/NewsPort';
+import type { NewsArticle } from '@/domain/newsArticle';
+
+const mockFetchNews = jest.fn();
+
+const mockNewsPort: NewsPort = {
+  fetchNews: mockFetchNews,
+};
+
+const { getNewsArticlesTool } = createNewsTool({ newsPort: mockNewsPort });
+
+const mockArticle: NewsArticle = {
+  title: 'Bitcoin hits new high',
+  description: 'BTC surges past resistance levels',
+  url: 'https://example.com/btc-news',
+  publishedAt: '2026-02-22T12:00:00Z',
+  source: { name: 'CryptoNews' },
+  content: 'Full article content here.',
+};
+
+describe('newsTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('dependency injection', () => {
+    it('should accept a NewsPort and create a tool', () => {
+      const tool = createNewsTool({ newsPort: mockNewsPort });
+      expect(tool.getNewsArticlesTool).toBeDefined();
+      expect(tool.getNewsArticlesTool.name).toBe('get_news_articles');
+    });
+
+    it('should call the injected newsPort, not a concrete adapter', async () => {
+      await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      expect(mockFetchNews).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful requests', () => {
+    it('should return articles for a valid symbol', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.symbol).toBe('BTC');
+      expect(parsed.count).toBe(1);
+      expect(parsed.data).toEqual([mockArticle]);
+    });
+
+    it('should uppercase the symbol before calling the port', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'btc' });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'BTC', limit: 5 });
+    });
+
+    it('should use default limit of 5 when not provided', async () => {
+      mockFetchNews.mockResolvedValue([]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'ETH' });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'ETH', limit: 5 });
+    });
+
+    it('should pass custom limit when provided', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'ETH', limit: 3 });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'ETH', limit: 3 });
+    });
+
+    it('should handle multiple articles', async () => {
+      const articles = [
+        mockArticle,
+        { ...mockArticle, title: 'Ethereum update' },
+        { ...mockArticle, title: 'Crypto market recap' },
+      ];
+      mockFetchNews.mockResolvedValue(articles);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.count).toBe(3);
+      expect(parsed.data).toHaveLength(3);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('should return error for empty symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: '' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+
+    it('should return error for null symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: null as unknown as string });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+
+    it('should return error for whitespace-only symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: '   ' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty results', () => {
+    it('should return empty data message when no articles found', async () => {
+      mockFetchNews.mockResolvedValue([]);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+      expect(parsed.message).toContain('No recent news articles found');
+      expect(parsed.data).toEqual([]);
+    });
+
+    it('should handle null response from port', async () => {
+      mockFetchNews.mockResolvedValue(null);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+    });
+  });
+
+  describe('API errors', () => {
+    it('should handle NEWS_API_KEY errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Missing NEWS_API_KEY'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('News API is not configured');
+      expect(parsed.fallback).toBeDefined();
+    });
+
+    it('should handle rate limit errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('rate limit exceeded'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Rate limit exceeded');
+    });
+
+    it('should handle 429 status errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('HTTP 429 Too Many Requests'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Rate limit exceeded');
+    });
+
+    it('should handle timeout errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Request timeout'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unable to connect to News API');
+    });
+
+    it('should handle connection refused errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unable to connect to News API');
+    });
+
+    it('should handle generic errors with context', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Something went wrong'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Failed to fetch news');
+      expect(parsed.error).toContain('BTC');
+      expect(parsed.error).toContain('Something went wrong');
+    });
+
+    it('should handle non-Error objects', async () => {
+      mockFetchNews.mockRejectedValue('string error');
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unknown error occurred');
+    });
+  });
+});

--- a/src/adapters/langchain/tools/__tests__/newsTool.test.ts
+++ b/src/adapters/langchain/tools/__tests__/newsTool.test.ts
@@ -1,0 +1,241 @@
+/** @jest-environment node */
+
+// Mock langchain before any imports
+jest.mock('langchain', () => ({
+  tool: jest.fn((func, config) => ({
+    invoke: func,
+    name: config.name,
+    description: config.description,
+    schema: config.schema,
+  })),
+}));
+
+// Mock zod
+jest.mock('zod', () => ({
+  z: {
+    object: jest.fn(() => ({})),
+    string: jest.fn(() => ({
+      describe: jest.fn(() => ({})),
+    })),
+    number: jest.fn(() => ({
+      min: jest.fn(() => ({
+        max: jest.fn(() => ({
+          optional: jest.fn(() => ({
+            describe: jest.fn(() => ({})),
+          })),
+        })),
+      })),
+    })),
+  },
+}));
+
+import { createNewsTool } from '../newsTool';
+import type { NewsPort } from '@/ports/NewsPort';
+import type { NewsArticle } from '@/domain/newsArticle';
+
+const mockFetchNews = jest.fn();
+
+const mockNewsPort: NewsPort = {
+  fetchNews: mockFetchNews,
+};
+
+const { getNewsArticlesTool } = createNewsTool({ newsPort: mockNewsPort });
+
+const mockArticle: NewsArticle = {
+  title: 'Bitcoin hits new high',
+  description: 'BTC surges past resistance levels',
+  url: 'https://example.com/btc-news',
+  publishedAt: '2026-02-22T12:00:00Z',
+  source: { name: 'CryptoNews' },
+  content: 'Full article content here.',
+};
+
+describe('newsTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('dependency injection', () => {
+    it('should accept a NewsPort and create a tool', () => {
+      const tool = createNewsTool({ newsPort: mockNewsPort });
+      expect(tool.getNewsArticlesTool).toBeDefined();
+      expect(tool.getNewsArticlesTool.name).toBe('get_news_articles');
+    });
+
+    it('should call the injected newsPort, not a concrete adapter', async () => {
+      await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      expect(mockFetchNews).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful requests', () => {
+    it('should return articles for a valid symbol', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.symbol).toBe('BTC');
+      expect(parsed.count).toBe(1);
+      expect(parsed.data).toEqual([mockArticle]);
+    });
+
+    it('should uppercase the symbol before calling the port', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'btc' });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'BTC', limit: 5 });
+    });
+
+    it('should use default limit of 5 when not provided', async () => {
+      mockFetchNews.mockResolvedValue([]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'ETH' });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'ETH', limit: 5 });
+    });
+
+    it('should pass custom limit when provided', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      await getNewsArticlesTool.invoke({ symbol: 'ETH', limit: 3 });
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'ETH', limit: 3 });
+    });
+
+    it('should handle multiple articles', async () => {
+      const articles = [
+        mockArticle,
+        { ...mockArticle, title: 'Ethereum update' },
+        { ...mockArticle, title: 'Crypto market recap' },
+      ];
+      mockFetchNews.mockResolvedValue(articles);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.count).toBe(3);
+      expect(parsed.data).toHaveLength(3);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('should return error for empty symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: '' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+
+    it('should return error for null symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: null as unknown as string });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+
+    it('should return error for whitespace-only symbol', async () => {
+      const result = await getNewsArticlesTool.invoke({ symbol: '   ' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Invalid symbol parameter');
+      expect(mockFetchNews).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty results', () => {
+    it('should return empty data message when no articles found', async () => {
+      mockFetchNews.mockResolvedValue([]);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+      expect(parsed.message).toContain('No recent news articles found');
+      expect(parsed.data).toEqual([]);
+    });
+
+    it('should handle null response from port', async () => {
+      mockFetchNews.mockResolvedValue(null);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+    });
+  });
+
+  describe('API errors', () => {
+    it('should handle NEWS_API_KEY errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Missing NEWS_API_KEY'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('News API is not configured');
+      expect(parsed.fallback).toBeUndefined();
+    });
+
+    it('should handle rate limit errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('rate limit exceeded'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Rate limit exceeded');
+    });
+
+    it('should handle 429 status errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('HTTP 429 Too Many Requests'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Rate limit exceeded');
+    });
+
+    it('should handle timeout errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Request timeout'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unable to connect to News API');
+    });
+
+    it('should handle connection refused errors', async () => {
+      mockFetchNews.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unable to connect to News API');
+    });
+
+    it('should handle generic errors with context', async () => {
+      mockFetchNews.mockRejectedValue(new Error('Something went wrong'));
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Failed to fetch news');
+      expect(parsed.error).toContain('BTC');
+      expect(parsed.error).toContain('Something went wrong');
+    });
+
+    it('should handle non-Error objects', async () => {
+      mockFetchNews.mockRejectedValue('string error');
+
+      const result = await getNewsArticlesTool.invoke({ symbol: 'BTC' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.error).toContain('Unknown error occurred');
+    });
+  });
+});

--- a/src/adapters/langchain/tools/__tests__/newsTool.test.ts
+++ b/src/adapters/langchain/tools/__tests__/newsTool.test.ts
@@ -81,12 +81,22 @@ describe('newsTool', () => {
       expect(parsed.data).toEqual([mockArticle]);
     });
 
-    it('should uppercase the symbol before calling the port', async () => {
+    it('should trim and uppercase the symbol before calling the port', async () => {
       mockFetchNews.mockResolvedValue([mockArticle]);
 
       await getNewsArticlesTool.invoke({ symbol: 'btc' });
 
       expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'BTC', limit: 5 });
+    });
+
+    it('should normalize whitespace-padded symbols', async () => {
+      mockFetchNews.mockResolvedValue([mockArticle]);
+
+      const result = await getNewsArticlesTool.invoke({ symbol: '  eth  ' });
+      const parsed = JSON.parse(result);
+
+      expect(mockFetchNews).toHaveBeenCalledWith({ symbol: 'ETH', limit: 5 });
+      expect(parsed.symbol).toBe('ETH');
     });
 
     it('should use default limit of 5 when not provided', async () => {

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -1,22 +1,10 @@
 import { tool } from 'langchain';
 import { z } from 'zod';
 import { NewsPort } from '@/ports/NewsPort';
-import { NewsAdapter } from '@/adapters/news/NewsAdapter';
-import { MockNewsAdapter } from '@/adapters/news/MockNewsAdapter';
-import { getEnv } from '@/lib/env';
 
-// Use mock adapter if NEWS_API_KEY not available
-function getNewsAdapter(): NewsPort {
-  try {
-    const env = getEnv();
-    return env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter();
-  } catch {
-    // Fallback to mock if env parsing fails
-    return new MockNewsAdapter();
-  }
+export interface NewsToolDeps {
+  newsPort: NewsPort;
 }
-
-const newsAdapter = getNewsAdapter();
 
 /**
  * Validates symbol parameter.
@@ -39,7 +27,6 @@ function handleNewsToolError(error: unknown, symbol: string): string {
   if (errorMessage.includes('NEWS_API_KEY')) {
     return JSON.stringify({
       error: 'News API is not configured. Please set NEWS_API_KEY environment variable.',
-      fallback: 'Mock data may be returned instead.',
     });
   }
 
@@ -60,88 +47,59 @@ function handleNewsToolError(error: unknown, symbol: string): string {
   });
 }
 
-export const getNewsArticlesTool = tool(
-  async ({ symbol, limit }: { symbol: string; limit?: number }) => {
-    try {
-      const validationError = validateSymbol(symbol);
-      if (validationError) {
-        return validationError;
-      }
-
-      const upperSymbol = symbol.toUpperCase();
-      const requestLimit = limit ?? 5;
-      let articles: Awaited<ReturnType<NewsPort['fetchNews']>> = [];
-      let usedMockFallback = false;
-      let source: 'live' | 'mock' = newsAdapter instanceof MockNewsAdapter ? 'mock' : 'live';
-
-      // Try the primary adapter first
-      if (newsAdapter instanceof NewsAdapter) {
-        try {
-          articles = await newsAdapter.fetchNews({
-            symbol: upperSymbol,
-            limit: requestLimit,
-          });
-        } catch {
-          // Real adapter threw an error, fall back to mock
-          usedMockFallback = true;
+export function createNewsTool(deps: NewsToolDeps) {
+  const getNewsArticlesTool = tool(
+    async ({ symbol, limit }: { symbol: string; limit?: number }) => {
+      try {
+        const validationError = validateSymbol(symbol);
+        if (validationError) {
+          return validationError;
         }
 
-        // If real adapter returned empty (which can happen on internal errors due to graceful degradation),
-        // fall back to mock for better UX
-        if (!articles || articles.length === 0) {
-          usedMockFallback = true;
-        }
-
-        if (usedMockFallback) {
-          const mockAdapter = new MockNewsAdapter();
-          articles = await mockAdapter.fetchNews({
-            symbol: upperSymbol,
-            limit: requestLimit,
-          });
-          source = 'mock';
-        }
-      } else {
-        // Already using mock adapter
-        articles = await newsAdapter.fetchNews({
+        const upperSymbol = symbol.toUpperCase();
+        const requestLimit = limit ?? 5;
+        const articles = await deps.newsPort.fetchNews({
           symbol: upperSymbol,
           limit: requestLimit,
         });
-      }
 
-      if (!articles || articles.length === 0) {
+        if (!articles || articles.length === 0) {
+          return JSON.stringify({
+            success: true,
+            symbol,
+            count: 0,
+            message: 'No recent news articles found for this symbol.',
+            data: [],
+          });
+        }
+
         return JSON.stringify({
           success: true,
           symbol,
-          count: 0,
-          message: 'No recent news articles found for this symbol.',
-          data: [],
+          count: articles.length,
+          data: articles,
         });
+      } catch (error) {
+        return handleNewsToolError(error, symbol);
       }
-
-      return JSON.stringify({
-        success: true,
-        symbol,
-        count: articles.length,
-        data: articles,
-        source,
-        fallback: usedMockFallback,
-      });
-    } catch (error) {
-      return handleNewsToolError(error, symbol);
+    },
+    {
+      name: 'get_news_articles',
+      description:
+        'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns JSON array of news articles with title, description, url, publishedAt, source, and content.',
+      schema: z.object({
+        symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
+        limit: z
+          .number()
+          .min(1)
+          .max(10)
+          .optional()
+          .describe('Number of articles to fetch (default 5, max 10).'),
+      }),
     }
-  },
-  {
-    name: 'get_news_articles',
-    description:
-      'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns JSON array of news articles with title, description, url, publishedAt, source, and content.',
-    schema: z.object({
-      symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
-      limit: z
-        .number()
-        .min(1)
-        .max(10)
-        .optional()
-        .describe('Number of articles to fetch (default 5, max 10).'),
-    }),
-  }
-);
+  );
+
+  return { getNewsArticlesTool };
+}
+
+export type NewsTools = ReturnType<typeof createNewsTool>;

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -56,17 +56,17 @@ export function createNewsTool(deps: NewsToolDeps) {
           return validationError;
         }
 
-        const upperSymbol = symbol.toUpperCase();
+        const normalizedSymbol = symbol.trim().toUpperCase();
         const requestLimit = limit ?? 5;
         const articles = await deps.newsPort.fetchNews({
-          symbol: upperSymbol,
+          symbol: normalizedSymbol,
           limit: requestLimit,
         });
 
         if (!articles || articles.length === 0) {
           return JSON.stringify({
             success: true,
-            symbol,
+            symbol: normalizedSymbol,
             count: 0,
             message: 'No recent news articles found for this symbol.',
             data: [],
@@ -75,7 +75,7 @@ export function createNewsTool(deps: NewsToolDeps) {
 
         return JSON.stringify({
           success: true,
-          symbol,
+          symbol: normalizedSymbol,
           count: articles.length,
           data: articles,
         });
@@ -86,7 +86,7 @@ export function createNewsTool(deps: NewsToolDeps) {
     {
       name: 'get_news_articles',
       description:
-        'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns JSON array of news articles with title, description, url, publishedAt, source, and content.',
+        'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns a JSON object with success, symbol, count, and a data array of news articles.',
       schema: z.object({
         symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
         limit: z

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -1,22 +1,10 @@
 import { tool } from 'langchain';
 import { z } from 'zod';
 import { NewsPort } from '@/ports/NewsPort';
-import { NewsAdapter } from '@/adapters/news/NewsAdapter';
-import { MockNewsAdapter } from '@/adapters/news/MockNewsAdapter';
-import { getEnv } from '@/lib/env';
 
-// Use mock adapter if NEWS_API_KEY not available
-function getNewsAdapter(): NewsPort {
-  try {
-    const env = getEnv();
-    return env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter();
-  } catch {
-    // Fallback to mock if env parsing fails
-    return new MockNewsAdapter();
-  }
+export interface NewsToolDeps {
+  newsPort: NewsPort;
 }
-
-const newsAdapter = getNewsAdapter();
 
 /**
  * Validates symbol parameter.
@@ -60,88 +48,59 @@ function handleNewsToolError(error: unknown, symbol: string): string {
   });
 }
 
-export const getNewsArticlesTool = tool(
-  async ({ symbol, limit }: { symbol: string; limit?: number }) => {
-    try {
-      const validationError = validateSymbol(symbol);
-      if (validationError) {
-        return validationError;
-      }
-
-      const upperSymbol = symbol.toUpperCase();
-      const requestLimit = limit ?? 5;
-      let articles: Awaited<ReturnType<NewsPort['fetchNews']>> = [];
-      let usedMockFallback = false;
-      let source: 'live' | 'mock' = newsAdapter instanceof MockNewsAdapter ? 'mock' : 'live';
-
-      // Try the primary adapter first
-      if (newsAdapter instanceof NewsAdapter) {
-        try {
-          articles = await newsAdapter.fetchNews({
-            symbol: upperSymbol,
-            limit: requestLimit,
-          });
-        } catch {
-          // Real adapter threw an error, fall back to mock
-          usedMockFallback = true;
+export function createNewsTool(deps: NewsToolDeps) {
+  const getNewsArticlesTool = tool(
+    async ({ symbol, limit }: { symbol: string; limit?: number }) => {
+      try {
+        const validationError = validateSymbol(symbol);
+        if (validationError) {
+          return validationError;
         }
 
-        // If real adapter returned empty (which can happen on internal errors due to graceful degradation),
-        // fall back to mock for better UX
-        if (!articles || articles.length === 0) {
-          usedMockFallback = true;
-        }
-
-        if (usedMockFallback) {
-          const mockAdapter = new MockNewsAdapter();
-          articles = await mockAdapter.fetchNews({
-            symbol: upperSymbol,
-            limit: requestLimit,
-          });
-          source = 'mock';
-        }
-      } else {
-        // Already using mock adapter
-        articles = await newsAdapter.fetchNews({
+        const upperSymbol = symbol.toUpperCase();
+        const requestLimit = limit ?? 5;
+        const articles = await deps.newsPort.fetchNews({
           symbol: upperSymbol,
           limit: requestLimit,
         });
-      }
 
-      if (!articles || articles.length === 0) {
+        if (!articles || articles.length === 0) {
+          return JSON.stringify({
+            success: true,
+            symbol,
+            count: 0,
+            message: 'No recent news articles found for this symbol.',
+            data: [],
+          });
+        }
+
         return JSON.stringify({
           success: true,
           symbol,
-          count: 0,
-          message: 'No recent news articles found for this symbol.',
-          data: [],
+          count: articles.length,
+          data: articles,
         });
+      } catch (error) {
+        return handleNewsToolError(error, symbol);
       }
-
-      return JSON.stringify({
-        success: true,
-        symbol,
-        count: articles.length,
-        data: articles,
-        source,
-        fallback: usedMockFallback,
-      });
-    } catch (error) {
-      return handleNewsToolError(error, symbol);
+    },
+    {
+      name: 'get_news_articles',
+      description:
+        'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns JSON array of news articles with title, description, url, publishedAt, source, and content.',
+      schema: z.object({
+        symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
+        limit: z
+          .number()
+          .min(1)
+          .max(10)
+          .optional()
+          .describe('Number of articles to fetch (default 5, max 10).'),
+      }),
     }
-  },
-  {
-    name: 'get_news_articles',
-    description:
-      'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns JSON array of news articles with title, description, url, publishedAt, source, and content.',
-    schema: z.object({
-      symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
-      limit: z
-        .number()
-        .min(1)
-        .max(10)
-        .optional()
-        .describe('Number of articles to fetch (default 5, max 10).'),
-    }),
-  }
-);
+  );
+
+  return { getNewsArticlesTool };
+}
+
+export type NewsTools = ReturnType<typeof createNewsTool>;


### PR DESCRIPTION
This pull request refactors how the news tool is integrated into the `LangChainAiAdapter`, improving dependency injection and simplifying error handling. The most important changes include replacing the previous static news tool with a dependency-injected version, updating the adapter's constructor to accept a `NewsPort`, and streamlining the tool logic to rely on the provided port rather than managing fallback logic internally.

Dependency injection and adapter improvements:

* The `LangChainAiAdapter` now accepts a `news` dependency of type `NewsPort` in its constructor, allowing for easier testing and flexibility in choosing between live and mock news adapters. [[1]](diffhunk://#diff-8a81f81aa2fee1ca9e76ad34d07c8abdfcea5cc18d7c2814a0d89c172d2dabf7R159-R161) [[2]](diffhunk://#diff-8a81f81aa2fee1ca9e76ad34d07c8abdfcea5cc18d7c2814a0d89c172d2dabf7R183-R186)
* The news tool is now created via the new `createNewsTool` factory function, which takes a `newsPort` and returns the tool, rather than using a static instance. This enables better separation of concerns and more robust error handling. [[1]](diffhunk://#diff-8a81f81aa2fee1ca9e76ad34d07c8abdfcea5cc18d7c2814a0d89c172d2dabf7L4-R11) [[2]](diffhunk://#diff-3baa464c73c9d1a532d47f7d8cab164ab2dfe064f31ed2473e8af05d48fa00cdL4-L20) [[3]](diffhunk://#diff-3baa464c73c9d1a532d47f7d8cab164ab2dfe064f31ed2473e8af05d48fa00cdL63-R52) [[4]](diffhunk://#diff-3baa464c73c9d1a532d47f7d8cab164ab2dfe064f31ed2473e8af05d48fa00cdR102-R106)

Tool logic simplification:

* The fallback logic for choosing between live and mock news adapters has been removed from the tool itself. Instead, the adapter determines which port to use and passes it in, reducing complexity and making the tool easier to maintain.
* The result structure returned by the news tool no longer includes `source` and `fallback` fields, reflecting the simplified logic and clearer responsibility boundaries.

Usage updates:

* Calls to the news tool within `LangChainAiAdapter` are updated to use the injected instance (`this.getNewsArticlesTool`) rather than the old static import.