### PR TITLE
fix(L5): move adapter instantiation to lib/data wiring layer

### DIFF
--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { LangChainAiAdapter } from '@/adapters/langchain/LangChainAiAdapter';
-import { getAiAnalysis } from '@/usecases/getAiAnalysis';
+import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
 
 export async function POST(
   req: Request,
@@ -16,10 +15,7 @@ export async function POST(
       );
     }
 
-    const analysis = await getAiAnalysis(
-      { ai: new LangChainAiAdapter() },
-      symbol
-    );
+    const analysis = await analyzeAsset(symbol);
 
     return NextResponse.json({ analysis }, { status: 200 });
   } catch (e) {

--- a/lib/data/aiAnalysisServer.ts
+++ b/lib/data/aiAnalysisServer.ts
@@ -1,0 +1,6 @@
+import { LangChainAiAdapter } from '@/adapters/langchain/LangChainAiAdapter';
+import { getAiAnalysis } from '@/usecases/getAiAnalysis';
+
+export async function analyzeAsset(symbol: string): Promise<string> {
+  return getAiAnalysis({ ai: new LangChainAiAdapter() }, symbol);
+}


### PR DESCRIPTION
This pull request refactors how AI analysis is handled in the API route for asset analysis. The main change is the extraction of the AI analysis logic into a new server-side utility function, improving code organization and reusability.

**Refactoring and Code Organization:**

* Moved the AI analysis logic from the `POST` handler in `app/api/ai-analysis/[symbol]/route.ts` to a new `analyzeAsset` function in `lib/data/aiAnalysisServer.ts`, simplifying the route handler and centralizing the analysis logic. ([app/api/ai-analysis/[symbol]/route.tsL2-R2](diffhunk://#diff-33ba3cc4bb71ff76f9901c9ca30b35151ed9104d87eead6190397de3a3f72366L2-R2), [app/api/ai-analysis/[symbol]/route.tsL19-R18](diffhunk://#diff-33ba3cc4bb71ff76f9901c9ca30b35151ed9104d87eead6190397de3a3f72366L19-R18), [lib/data/aiAnalysisServer.tsR1-R6](diffhunk://#diff-897c0a077150eeac724266e1df756cb15b115e530fb1ceb9317a4b64b2bd82acR1-R6))
* Created the `analyzeAsset` function in `aiAnalysisServer.ts`, which wraps the existing `getAiAnalysis` call with the `LangChainAiAdapter`, making it easier to reuse this logic elsewhere in the codebase.