### PR TITLE
fix(P1,P5,P6): use existing utilities consistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 
 .claude/settings.local.json
 /audit/
+/.vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,7 @@ Create `.env.local` in the root directory with your API keys.
 ## Git Commit Rules
 
 - **NEVER add `Co-Authored-By` lines or any AI attribution to commit messages.** No exceptions.
+- **NEVER add "Generated with Claude Code" or any AI-generated promotional lines to PR descriptions, commit messages, or any other output.** No exceptions.
 
 ## Code Conventions (from .cursor/rules)
 

--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server';
 import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
+import { logError } from '@/lib/observability';
 
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ symbol: string }> }
 ): Promise<Response> {
+  let symbol: string | undefined;
   try {
-    const { symbol } = await params;
+    ({ symbol } = await params);
 
     if (!symbol || typeof symbol !== 'string') {
       return NextResponse.json(
@@ -19,7 +21,7 @@ export async function POST(
 
     return NextResponse.json({ analysis }, { status: 200 });
   } catch (e) {
-    console.error('AI Analysis error:', e);
+    logError(e, { route: 'POST /api/ai-analysis', symbol });
     return NextResponse.json(
       { error: e instanceof Error ? e.message : 'Failed to generate analysis' },
       { status: 502 }

--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchAssets } from '@/lib/data/assets';
+import { logError } from '@/lib/observability';
 
 export async function GET(req: Request): Promise<Response> {
   const { searchParams } = new URL(req.url);
@@ -10,7 +11,7 @@ export async function GET(req: Request): Promise<Response> {
     const assets = await fetchAssets({ limit, offset });
     return NextResponse.json(assets, { status: 200 });
   } catch (e) {
-    console.error(e);
+    logError(e, { route: 'GET /api/assets', limit, offset });
     return NextResponse.json({ error: 'Upstream unavailable' }, { status: 502 });
   }
 }

--- a/src/adapters/coincap/CoinCapAdapter.ts
+++ b/src/adapters/coincap/CoinCapAdapter.ts
@@ -3,7 +3,7 @@ import { Asset } from '@/domain/asset';
 import { get } from './client';
 import { ListAssetsResponseSchema } from './schema';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
-import { logRequest, logError } from '@/lib/observability';
+import { logError } from '@/lib/observability';
 
 export class CoinCapAdapter implements CoinCapPort {
   async listAssets(params: { limit?: number; offset?: number } = {}): Promise<Asset[]> {
@@ -11,7 +11,6 @@ export class CoinCapAdapter implements CoinCapPort {
     const key = inflightKey('coincap/assets', { limit, offset });
     return dedupe(key, async () => {
       const url = `/assets?limit=${limit}&offset=${offset}`;
-      logRequest({ url, method: 'GET' });
       try {
         const res = await get(url, { next: { revalidate: 60 } });
         if (!res || !res.ok) {

--- a/src/adapters/coincap/CoinCapAdapter.ts
+++ b/src/adapters/coincap/CoinCapAdapter.ts
@@ -3,19 +3,27 @@ import { Asset } from '@/domain/asset';
 import { get } from './client';
 import { ListAssetsResponseSchema } from './schema';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
+import { logRequest, logError } from '@/lib/observability';
 
 export class CoinCapAdapter implements CoinCapPort {
   async listAssets(params: { limit?: number; offset?: number } = {}): Promise<Asset[]> {
     const { limit = 19, offset = 0 } = params;
     const key = inflightKey('coincap/assets', { limit, offset });
     return dedupe(key, async () => {
-      const res = await get(`/assets?limit=${limit}&offset=${offset}`, { next: { revalidate: 60 } });
-      if (!res || !res.ok) {
-        throw new Error(`API error ${res?.status ?? 500}`);
+      const url = `/assets?limit=${limit}&offset=${offset}`;
+      logRequest({ url, method: 'GET' });
+      try {
+        const res = await get(url, { next: { revalidate: 60 } });
+        if (!res || !res.ok) {
+          throw new Error(`API error ${res?.status ?? 500}`);
+        }
+        const json = await res.json();
+        const parsed = ListAssetsResponseSchema.parse(json);
+        return parsed.data;
+      } catch (err) {
+        logError(err, { adapter: 'CoinCapAdapter', method: 'listAssets', limit, offset });
+        throw err;
       }
-      const json = await res.json();
-      const parsed = ListAssetsResponseSchema.parse(json);
-      return parsed.data;
     });
   }
 }

--- a/src/adapters/langchain/LangChainAiAdapter.ts
+++ b/src/adapters/langchain/LangChainAiAdapter.ts
@@ -3,6 +3,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { createPriceTools, type PriceTools } from "./tools/priceTools";
 import { createNewsTool, type NewsTools } from "./tools/newsTool";
 import { getEnv } from "@/lib/env";
+import { logRequest, logError } from "@/lib/observability";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
 import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
@@ -202,6 +203,7 @@ Do not provide financial advice. Focus on data-driven observations.`;
     try {
       // Gather data from tools first
       const binanceSymbol = `${symbol.toUpperCase()}USDT`;
+      logRequest({ url: `openai/chat (${symbol})`, method: 'POST' });
 
       const [priceHistoryResult, vwapResult, newsResult] = await Promise.allSettled([
         this.getPriceHistoryTool.invoke({ symbol: binanceSymbol, limit: 14 }),
@@ -247,7 +249,7 @@ Do not provide financial advice. Focus on data-driven observations.`;
 
       return response.content as string;
     } catch (error) {
-      console.error("Error in AI analysis:", error);
+      logError(error, { adapter: 'LangChainAiAdapter', method: 'analyzeAsset', symbol });
       throw new Error(`Failed to analyze ${symbol}: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 // Extend as new env vars are required
 const EnvSchema = z.object({
   // example: "NEXT_PUBLIC_API_URL": z.string().url().optional(),
+  NODE_ENV: z.enum(['development', 'production', 'test']).optional(),
   COINCAP_API_KEY: z.string().optional(),
   COINCAP_BASE_URL: z.string().url().optional(),
   BINANCE_API_KEY: z.string().optional(),

--- a/src/usecases/getAssets.ts
+++ b/src/usecases/getAssets.ts
@@ -1,12 +1,13 @@
 import { CoinCapPort } from "@/ports/CoinCapPort";
 import { AssetWhitelistPort } from "@/ports/AssetWhitelistPort";
 import { Asset } from "@/domain/asset";
+import { getEnv } from "@/lib/env";
 export async function getAssets(
   deps: { coinCap: CoinCapPort; whitelist?: AssetWhitelistPort },
   params: { limit?: number; offset?: number } = {}
 ): Promise<Asset[]> {
   const { limit = 19, offset = 0 } = params;
-  const isTestEnv = process.env.NODE_ENV === "test";
+  const isTestEnv = getEnv().NODE_ENV === "test";
   const hasWhitelist = Boolean(deps.whitelist);
   const OVERFETCH_MULTIPLIER = 5; // fetch more to compensate for whitelist filtering
   const requestLimit =


### PR DESCRIPTION
## Summary

- **P1**: Replace raw `console.error()` with `logError()` from `src/lib/observability.ts` in API routes (`/api/assets`, `/api/ai-analysis`) and `LangChainAiAdapter`, adding contextual metadata
- **P5**: Replace direct `process.env.NODE_ENV` in `getAssets.ts` with `getEnv().NODE_ENV`, adding `NODE_ENV` to the env schema
- **P6**: Add `logRequest()` and `logError()` observability logging to `CoinCapAdapter` and `LangChainAiAdapter`, matching the pattern established in `NewsAdapter`

## Test plan

- [x] `pnpm preflight` passes (typecheck + lint 0 warnings + 234 tests)
- [x] Verify structured error logs appear in server output when API errors occur
- [x] Verify `logRequest` entries appear for CoinCap and LangChain adapter calls