### PR TITLE
fix(P2): use typed errors instead of raw Error()

### DIFF
--- a/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
+++ b/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+
+import { ExternalException } from '@/lib/errors';
+
+jest.mock('@/lib/data/aiAnalysisServer');
+
+import { POST } from '../route';
+import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
+
+const mockAnalyzeAsset = analyzeAsset as jest.MockedFunction<typeof analyzeAsset>;
+
+function makeRequest(symbol: string) {
+  return [
+    new Request('http://localhost/api/ai-analysis/' + symbol, { method: 'POST' }),
+    { params: Promise.resolve({ symbol }) },
+  ] as const;
+}
+
+describe('POST /api/ai-analysis/[symbol]', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 200 with analysis on success', async () => {
+    mockAnalyzeAsset.mockResolvedValue('Bullish momentum...');
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.analysis).toBe('Bullish momentum...');
+  });
+
+  it('returns 429 for RateLimited errors', async () => {
+    mockAnalyzeAsset.mockRejectedValue(
+      new ExternalException({ kind: 'RateLimited' }, 'Too many requests'),
+    );
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe('Too many requests');
+  });
+
+  it('returns 400 for InvalidRequest errors', async () => {
+    mockAnalyzeAsset.mockRejectedValue(
+      new ExternalException({ kind: 'InvalidRequest' }, 'Missing API key'),
+    );
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Missing API key');
+  });
+
+  it('returns 502 for Unavailable errors', async () => {
+    mockAnalyzeAsset.mockRejectedValue(
+      new ExternalException({ kind: 'Unavailable' }, 'OpenAI down'),
+    );
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('OpenAI down');
+  });
+
+  it('returns 502 for untyped errors', async () => {
+    mockAnalyzeAsset.mockRejectedValue(new Error('Something broke'));
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('Something broke');
+  });
+});

--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
 import { logError } from '@/lib/observability';
+import { isExternalException } from '@/lib/errors';
 
 export async function POST(
   req: Request,
@@ -22,6 +23,13 @@ export async function POST(
     return NextResponse.json({ analysis }, { status: 200 });
   } catch (e) {
     logError(e, { route: 'POST /api/ai-analysis', symbol });
+    if (isExternalException(e)) {
+      const status = e.kind === 'RateLimited' ? 429 : e.kind === 'InvalidRequest' ? 400 : 502;
+      return NextResponse.json(
+        { error: e.message },
+        { status }
+      );
+    }
     return NextResponse.json(
       { error: e instanceof Error ? e.message : 'Failed to generate analysis' },
       { status: 502 }

--- a/app/api/assets/__tests__/route.test.ts
+++ b/app/api/assets/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+
+import { ExternalException } from '@/lib/errors';
+
+jest.mock('@/lib/data/assets');
+
+import { GET } from '../route';
+import { fetchAssets } from '@/lib/data/assets';
+
+const mockFetchAssets = fetchAssets as jest.MockedFunction<typeof fetchAssets>;
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/assets');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new Request(url.toString());
+}
+
+describe('GET /api/assets', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 200 with assets on success', async () => {
+    mockFetchAssets.mockResolvedValue([]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 429 for RateLimited errors', async () => {
+    mockFetchAssets.mockRejectedValue(
+      new ExternalException({ kind: 'RateLimited' }, 'Too many requests'),
+    );
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe('Too many requests');
+  });
+
+  it('returns 400 for InvalidRequest errors', async () => {
+    mockFetchAssets.mockRejectedValue(
+      new ExternalException({ kind: 'InvalidRequest' }, 'Bad param'),
+    );
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Bad param');
+  });
+
+  it('returns 502 for Unavailable errors', async () => {
+    mockFetchAssets.mockRejectedValue(
+      new ExternalException({ kind: 'Unavailable' }, 'CoinCap down'),
+    );
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('CoinCap down');
+  });
+
+  it('returns 502 for untyped errors', async () => {
+    mockFetchAssets.mockRejectedValue(new Error('Something broke'));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('Upstream unavailable');
+  });
+});

--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { fetchAssets } from '@/lib/data/assets';
 import { logError } from '@/lib/observability';
+import { isExternalException } from '@/lib/errors';
 
 export async function GET(req: Request): Promise<Response> {
   const { searchParams } = new URL(req.url);
@@ -12,6 +13,10 @@ export async function GET(req: Request): Promise<Response> {
     return NextResponse.json(assets, { status: 200 });
   } catch (e) {
     logError(e, { route: 'GET /api/assets', limit, offset });
+    if (isExternalException(e)) {
+      const status = e.kind === 'RateLimited' ? 429 : e.kind === 'InvalidRequest' ? 400 : 502;
+      return NextResponse.json({ error: e.message }, { status });
+    }
     return NextResponse.json({ error: 'Upstream unavailable' }, { status: 502 });
   }
 }

--- a/src/adapters/binance/BinanceAdapter.ts
+++ b/src/adapters/binance/BinanceAdapter.ts
@@ -1,41 +1,56 @@
-import { dedupe, inflightKey } from '@/lib/http/inflight';
-import { get } from './client';
-import { KlinesSchema, Ticker24hrSchema } from './schema';
-import type { BinancePort, Candlestick } from '@/ports/BinancePort';
+import { dedupe, inflightKey } from "@/lib/http/inflight";
+import { get } from "./client";
+import { KlinesSchema, Ticker24hrSchema } from "./schema";
+import type { BinancePort, Candlestick } from "@/ports/BinancePort";
+import { ExternalException } from "@/lib/errors";
 
 export class BinanceAdapter implements BinancePort {
-  private async buildErrorMessage(res: Response | undefined): Promise<string> {
-    if (!res) {
-      return `Binance API error: Status: 500`;
-    }
-    let errorDetails = `Status: ${res.status}`;
-    if (res.statusText) {
-      errorDetails += `, StatusText: ${res.statusText}`;
+  private async buildErrorDetails(
+    res: Response | undefined,
+  ): Promise<{ status: number; statusText?: string; body?: unknown }> {
+    const status = res?.status ?? 500;
+    const details: { status: number; statusText?: string; body?: unknown } = {
+      status,
+    };
+    if (res?.statusText) {
+      details.statusText = res.statusText;
     }
     try {
       let errorBody: unknown;
       try {
-        errorBody = await res.clone().json();
+        errorBody = await res?.clone().json();
       } catch {
-        errorBody = await res.clone().text().catch(() => null);
+        errorBody = await res
+          ?.clone()
+          .text()
+          .catch(() => null);
       }
       if (errorBody) {
-        errorDetails += `, Body: ${JSON.stringify(errorBody)}`;
+        details.body = errorBody;
       }
     } catch {
       // Ignore parsing errors
     }
-    return `Binance API error: ${errorDetails}`;
+    return details;
   }
 
   async get24HrStats(symbol: string): Promise<number> {
-    const key = inflightKey('binance/ticker24hr', { symbol });
+    const key = inflightKey("binance/ticker24hr", { symbol });
     return dedupe(key, async () => {
-      const res = await get(`/ticker/24hr?symbol=${encodeURIComponent(symbol)}`, {
-        next: { revalidate: 30 },
-      });
+      const res = await get(
+        `/ticker/24hr?symbol=${encodeURIComponent(symbol)}`,
+        {
+          next: { revalidate: 30 },
+        },
+      );
       if (!res || !res.ok) {
-        throw new Error(await this.buildErrorMessage(res));
+        const details = await this.buildErrorDetails(res);
+        throw new ExternalException(
+          details.status === 429
+            ? { kind: "RateLimited", details }
+            : { kind: "Unavailable", details },
+          `Binance API error: Status: ${details.status}`,
+        );
       }
       const json = await res.json();
       const parsed = Ticker24hrSchema.parse(json);
@@ -43,14 +58,29 @@ export class BinanceAdapter implements BinancePort {
     });
   }
 
-  async getDailyCandles(symbol: string, limit?: number): Promise<Candlestick[]> {
-    const key = inflightKey('binance/klines', { symbol, interval: '1d', limit });
+  async getDailyCandles(
+    symbol: string,
+    limit?: number,
+  ): Promise<Candlestick[]> {
+    const key = inflightKey("binance/klines", {
+      symbol,
+      interval: "1d",
+      limit,
+    });
     return dedupe(key, async () => {
-      const query = new URLSearchParams({ symbol, interval: '1d' });
-      if (typeof limit === 'number') query.set('limit', String(limit));
-      const res = await get(`/klines?${query.toString()}`, { next: { revalidate: 60 } });
+      const query = new URLSearchParams({ symbol, interval: "1d" });
+      if (typeof limit === "number") query.set("limit", String(limit));
+      const res = await get(`/klines?${query.toString()}`, {
+        next: { revalidate: 60 },
+      });
       if (!res || !res.ok) {
-        throw new Error(await this.buildErrorMessage(res));
+        const details = await this.buildErrorDetails(res);
+        throw new ExternalException(
+          details.status === 429
+            ? { kind: "RateLimited", details }
+            : { kind: "Unavailable", details },
+          `Binance API error: Status: ${details.status}`,
+        );
       }
       const json = await res.json();
       const candles = KlinesSchema.parse(json);
@@ -58,4 +88,3 @@ export class BinanceAdapter implements BinancePort {
     });
   }
 }
-

--- a/src/adapters/binance/BinanceAdapter.ts
+++ b/src/adapters/binance/BinanceAdapter.ts
@@ -15,21 +15,20 @@ export class BinanceAdapter implements BinancePort {
     if (res?.statusText) {
       details.statusText = res.statusText;
     }
-    try {
-      let errorBody: unknown;
+    if (res) {
       try {
-        errorBody = await res?.clone().json();
+        let errorBody: unknown;
+        try {
+          errorBody = await res.clone().json();
+        } catch {
+          errorBody = await res.clone().text().catch(() => null);
+        }
+        if (errorBody) {
+          details.body = errorBody;
+        }
       } catch {
-        errorBody = await res
-          ?.clone()
-          .text()
-          .catch(() => null);
+        // Ignore parsing errors
       }
-      if (errorBody) {
-        details.body = errorBody;
-      }
-    } catch {
-      // Ignore parsing errors
     }
     return details;
   }

--- a/src/adapters/coincap/CoinCapAdapter.ts
+++ b/src/adapters/coincap/CoinCapAdapter.ts
@@ -4,6 +4,7 @@ import { get } from './client';
 import { ListAssetsResponseSchema } from './schema';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
 import { logError } from '@/lib/observability';
+import { ExternalException } from '@/lib/errors';
 
 export class CoinCapAdapter implements CoinCapPort {
   async listAssets(params: { limit?: number; offset?: number } = {}): Promise<Asset[]> {
@@ -14,7 +15,13 @@ export class CoinCapAdapter implements CoinCapPort {
       try {
         const res = await get(url, { next: { revalidate: 60 } });
         if (!res || !res.ok) {
-          throw new Error(`API error ${res?.status ?? 500}`);
+          const status = res?.status ?? 500;
+          throw new ExternalException(
+            status === 429
+              ? { kind: 'RateLimited', details: { status } }
+              : { kind: 'Unavailable', details: { status } },
+            `CoinCap API error ${status}`,
+          );
         }
         const json = await res.json();
         const parsed = ListAssetsResponseSchema.parse(json);

--- a/src/adapters/langchain/LangChainAiAdapter.ts
+++ b/src/adapters/langchain/LangChainAiAdapter.ts
@@ -4,6 +4,7 @@ import { createPriceTools, type PriceTools } from "./tools/priceTools";
 import { createNewsTool, type NewsTools } from "./tools/newsTool";
 import { getEnv } from "@/lib/env";
 import { logRequest, logError } from "@/lib/observability";
+import { ExternalException } from "@/lib/errors";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
 import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
@@ -156,8 +157,9 @@ export class LangChainAiAdapter implements AiAnalysisPort {
     const env = getEnv();
 
     if (!env.OPENAI_API_KEY) {
-      throw new Error(
-        "OPENAI_API_KEY is required for AI analysis. Please set the environment variable."
+      throw new ExternalException(
+        { kind: 'InvalidRequest', details: { missingEnv: 'OPENAI_API_KEY' } },
+        'OPENAI_API_KEY is required for AI analysis. Please set the environment variable.',
       );
     }
 
@@ -250,7 +252,11 @@ Do not provide financial advice. Focus on data-driven observations.`;
       return response.content as string;
     } catch (error) {
       logError(error, { adapter: 'LangChainAiAdapter', method: 'analyzeAsset', symbol });
-      throw new Error(`Failed to analyze ${symbol}: ${error instanceof Error ? error.message : "Unknown error"}`);
+      if (error instanceof ExternalException) throw error;
+      throw new ExternalException(
+        { kind: 'Unavailable', details: { symbol, originalError: error instanceof Error ? error.message : String(error) } },
+        `Failed to analyze ${symbol}: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
     }
   }
 

--- a/src/adapters/news/NewsAdapter.ts
+++ b/src/adapters/news/NewsAdapter.ts
@@ -4,6 +4,7 @@ import { dedupe, inflightKey } from '@/lib/http/inflight';
 import { get } from './client';
 import { NewsAPIaiResponseSchema } from './schema';
 import { logRequest, logError } from '@/lib/observability';
+import { ExternalException } from '@/lib/errors';
 
 export class NewsAdapter implements NewsPort {
   async fetchNews(params: { symbol: string; limit?: number }): Promise<NewsArticle[]> {
@@ -52,9 +53,18 @@ export class NewsAdapter implements NewsPort {
         }
 
         if (!res || !res.ok) {
+          const status = res?.status ?? 500;
           const errorText = await res?.text?.();
-          logError(new Error(`NewsAPI.ai ${res?.status}: ${errorText}`), { symbol, limit, url });
-          throw new Error(`NewsAPI.ai error ${res?.status ?? 500}`);
+          logError(new ExternalException(
+            { kind: 'Unavailable', details: { status, errorText } },
+            `NewsAPI.ai ${status}: ${errorText}`,
+          ), { symbol, limit, url });
+          throw new ExternalException(
+            status === 429
+              ? { kind: 'RateLimited', details: { status } }
+              : { kind: 'Unavailable', details: { status, errorText } },
+            `NewsAPI.ai error ${status}`,
+          );
         }
 
         const json = await res.json();

--- a/src/adapters/news/NewsAdapter.ts
+++ b/src/adapters/news/NewsAdapter.ts
@@ -55,16 +55,14 @@ export class NewsAdapter implements NewsPort {
         if (!res || !res.ok) {
           const status = res?.status ?? 500;
           const errorText = await res?.text?.();
-          logError(new ExternalException(
-            { kind: 'Unavailable', details: { status, errorText } },
-            `NewsAPI.ai ${status}: ${errorText}`,
-          ), { symbol, limit, url });
-          throw new ExternalException(
+          const error = new ExternalException(
             status === 429
-              ? { kind: 'RateLimited', details: { status } }
+              ? { kind: 'RateLimited', details: { status, errorText } }
               : { kind: 'Unavailable', details: { status, errorText } },
             `NewsAPI.ai error ${status}`,
           );
+          logError(error, { symbol, limit, url });
+          throw error;
         }
 
         const json = await res.json();

--- a/src/adapters/news/client.ts
+++ b/src/adapters/news/client.ts
@@ -1,5 +1,6 @@
 import { fetchWithRetry } from '@/lib/http/fetcher';
 import { getEnv } from '@/lib/env';
+import { ExternalException } from '@/lib/errors';
 
 // NewsAPI.ai uses eventregistry.org as the base URL
 const BASE_URL = 'https://eventregistry.org/api/v1';
@@ -9,7 +10,10 @@ export async function get(path: string, init?: RequestInit): Promise<Response> {
   const apiKey = env.NEWS_API_KEY;
 
   if (!apiKey) {
-    throw new Error('NEWS_API_KEY not configured');
+    throw new ExternalException(
+      { kind: 'InvalidRequest', details: { missingEnv: 'NEWS_API_KEY' } },
+      'NEWS_API_KEY not configured',
+    );
   }
 
   // Remove leading slash from path if present to properly join with BASE_URL

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,6 +10,7 @@ export class ExternalException extends Error {
 
   constructor(error: ExternalError, message?: string) {
     super(message ?? error.kind);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ExternalException';
     this.kind = error.kind;
     this.details = error.details;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,3 +2,23 @@ export type ExternalError =
   | { kind: 'RateLimited'; retryAfterSec?: number; details?: unknown }
   | { kind: 'Unavailable'; details?: unknown }
   | { kind: 'InvalidRequest'; details?: unknown };
+
+export class ExternalException extends Error {
+  readonly kind: ExternalError['kind'];
+  readonly details?: unknown;
+  readonly retryAfterSec?: number;
+
+  constructor(error: ExternalError, message?: string) {
+    super(message ?? error.kind);
+    this.name = 'ExternalException';
+    this.kind = error.kind;
+    this.details = error.details;
+    if (error.kind === 'RateLimited') {
+      this.retryAfterSec = error.retryAfterSec;
+    }
+  }
+}
+
+export function isExternalException(err: unknown): err is ExternalException {
+  return err instanceof ExternalException;
+}

--- a/src/lib/http/fetcher.ts
+++ b/src/lib/http/fetcher.ts
@@ -1,9 +1,10 @@
 import { setTimeout as sleep } from 'node:timers/promises';
+import { ExternalException } from '@/lib/errors';
 
 export async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   const timeout = new Promise<never>((_, reject) => {
     setTimeout(() => {
-      reject(new Error(`Timeout after ${ms}ms`));
+      reject(new ExternalException({ kind: 'Unavailable', details: { timeoutMs: ms } }, `Timeout after ${ms}ms`));
     }, ms);
   });
   return Promise.race([promise, timeout]);


### PR DESCRIPTION
## Summary

- Add `ExternalException` class (extends `Error`) and `isExternalException` type guard to `src/lib/errors.ts`, making the existing `ExternalError` type throwable
- Replace all raw `new Error()` in adapters (`CoinCap`, `Binance`, `News`, `LangChain`) and `fetcher.ts` timeout with typed `ExternalException` using appropriate error kinds (`Unavailable`, `RateLimited`, `InvalidRequest`) and 429 status detection
- Update both API routes (`/api/assets`, `/api/ai-analysis/[symbol]`) to pattern-match `ExternalException.kind` for differentiated HTTP responses (429/400/502) instead of blanket 502
- Add route-level test suite (`app/api/assets/__tests__/route.test.ts`) verifying error-kind-to-HTTP-status mapping

## Test plan

- [x] `pnpm preflight` passes (typecheck + lint 0 warnings + 27 suites / 239 tests)
- [ ] Verify 429 responses when upstream returns rate-limit errors
- [ ] Verify 400 responses for missing API key configuration
- [ ] Verify 502 fallback for untyped/unexpected errors