### PR TITLE
fix(P3): standardize input validation with zod

### DIFF
--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
 import { logError } from '@/lib/observability';
 import { isExternalException } from '@/lib/errors';
+import { symbolSchema } from '@/domain/schemas';
 
 export async function POST(
   req: Request,
@@ -11,7 +12,8 @@ export async function POST(
   try {
     ({ symbol } = await params);
 
-    if (!symbol || typeof symbol !== 'string') {
+    const parsed = symbolSchema.safeParse(symbol);
+    if (!parsed.success) {
       return NextResponse.json(
         { error: 'Invalid symbol parameter' },
         { status: 400 }

--- a/src/adapters/langchain/tools/__tests__/newsTool.test.ts
+++ b/src/adapters/langchain/tools/__tests__/newsTool.test.ts
@@ -11,23 +11,35 @@ jest.mock('langchain', () => ({
 }));
 
 // Mock zod
-jest.mock('zod', () => ({
-  z: {
-    object: jest.fn(() => ({})),
-    string: jest.fn(() => ({
-      describe: jest.fn(() => ({})),
-    })),
-    number: jest.fn(() => ({
-      min: jest.fn(() => ({
-        max: jest.fn(() => ({
-          optional: jest.fn(() => ({
-            describe: jest.fn(() => ({})),
+jest.mock('zod', () => {
+  const stringChain: Record<string, jest.Mock> = {};
+  stringChain.describe = jest.fn(() => stringChain);
+  stringChain.trim = jest.fn(() => stringChain);
+  stringChain.min = jest.fn(() => stringChain);
+  stringChain.max = jest.fn(() => stringChain);
+  stringChain.safeParse = jest.fn((val: unknown) => {
+    if (typeof val === 'string' && val.trim().length > 0 && val.trim().length <= 20) {
+      return { success: true, data: val.trim() };
+    }
+    return { success: false, error: { issues: [{ message: 'Invalid' }] } };
+  });
+
+  return {
+    z: {
+      object: jest.fn(() => ({})),
+      string: jest.fn(() => stringChain),
+      number: jest.fn(() => ({
+        min: jest.fn(() => ({
+          max: jest.fn(() => ({
+            optional: jest.fn(() => ({
+              describe: jest.fn(() => ({})),
+            })),
           })),
         })),
       })),
-    })),
-  },
-}));
+    },
+  };
+});
 
 import { createNewsTool } from '../newsTool';
 import type { NewsPort } from '@/ports/NewsPort';

--- a/src/adapters/langchain/tools/__tests__/priceTools.test.ts
+++ b/src/adapters/langchain/tools/__tests__/priceTools.test.ts
@@ -11,19 +11,30 @@ jest.mock('langchain', () => ({
 }));
 
 // Mock zod
-jest.mock('zod', () => ({
-  z: {
-    object: jest.fn(() => ({})),
-    string: jest.fn(() => ({
-      describe: jest.fn(() => ({})),
-    })),
-    number: jest.fn(() => ({
-      describe: jest.fn(() => ({
-        optional: jest.fn(() => ({})),
+jest.mock('zod', () => {
+  const stringChain: Record<string, jest.Mock> = {};
+  stringChain.describe = jest.fn(() => stringChain);
+  stringChain.min = jest.fn(() => stringChain);
+  stringChain.max = jest.fn(() => stringChain);
+  stringChain.safeParse = jest.fn((val: unknown) => {
+    if (typeof val === 'string' && val.length > 0) {
+      return { success: true, data: val };
+    }
+    return { success: false, error: { issues: [{ message: 'Invalid' }] } };
+  });
+
+  return {
+    z: {
+      object: jest.fn(() => ({})),
+      string: jest.fn(() => stringChain),
+      number: jest.fn(() => ({
+        describe: jest.fn(() => ({
+          optional: jest.fn(() => ({})),
+        })),
       })),
-    })),
-  },
-}));
+    },
+  };
+});
 
 import { createPriceTools } from '../priceTools';
 import type { Candlestick } from '@/ports/BinancePort';

--- a/src/adapters/langchain/tools/__tests__/priceTools.test.ts
+++ b/src/adapters/langchain/tools/__tests__/priceTools.test.ts
@@ -16,9 +16,10 @@ jest.mock('zod', () => {
   stringChain.describe = jest.fn(() => stringChain);
   stringChain.min = jest.fn(() => stringChain);
   stringChain.max = jest.fn(() => stringChain);
+  stringChain.trim = jest.fn(() => stringChain);
   stringChain.safeParse = jest.fn((val: unknown) => {
-    if (typeof val === 'string' && val.length > 0) {
-      return { success: true, data: val };
+    if (typeof val === 'string' && val.trim().length > 0 && val.trim().length <= 20) {
+      return { success: true, data: val.trim() };
     }
     return { success: false, error: { issues: [{ message: 'Invalid' }] } };
   });

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -1,18 +1,20 @@
 import { tool } from 'langchain';
 import { z } from 'zod';
 import { NewsPort } from '@/ports/NewsPort';
+import { symbolSchema } from '@/domain/schemas';
 
 export interface NewsToolDeps {
   newsPort: NewsPort;
 }
 
 /**
- * Validates symbol parameter.
+ * Validates symbol parameter using Zod.
  */
 function validateSymbol(symbol: unknown): string | null {
-  if (!symbol || typeof symbol !== 'string' || symbol.trim() === '') {
+  const result = symbolSchema.safeParse(symbol);
+  if (!result.success) {
     return JSON.stringify({
-      error: 'Invalid symbol parameter. Symbol must be a non-empty string (e.g., "BTC", "ETH").',
+      error: 'Invalid symbol parameter. Symbol must be a non-empty string with maximum 20 characters (e.g., "BTC", "ETH").',
     });
   }
   return null;

--- a/src/adapters/langchain/tools/priceTools.ts
+++ b/src/adapters/langchain/tools/priceTools.ts
@@ -1,6 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { Candlestick } from "@/ports/BinancePort";
+import { symbolSchema } from "@/domain/schemas";
 
 export interface PriceToolDeps {
   getPriceHistory: (params: { symbol: string; limit?: number }) => Promise<Candlestick[]>;
@@ -41,12 +42,13 @@ function handlePriceToolError(error: unknown, symbol: string, operation: string)
 }
 
 /**
- * Validates that a symbol parameter is a non-empty string.
+ * Validates that a symbol parameter is a non-empty string using Zod.
  * @param symbol - The symbol to validate
  * @returns JSON stringified error object if invalid, null if valid
  */
 function validateSymbol(symbol: unknown): string | null {
-  if (!symbol || typeof symbol !== 'string') {
+  const result = symbolSchema.safeParse(symbol);
+  if (!result.success) {
     return JSON.stringify({
       error: 'Invalid symbol parameter. Symbol must be a non-empty string (e.g., "BTCUSDT").',
     });

--- a/src/adapters/langchain/tools/priceTools.ts
+++ b/src/adapters/langchain/tools/priceTools.ts
@@ -50,7 +50,7 @@ function validateSymbol(symbol: unknown): string | null {
   const result = symbolSchema.safeParse(symbol);
   if (!result.success) {
     return JSON.stringify({
-      error: 'Invalid symbol parameter. Symbol must be a non-empty string (e.g., "BTCUSDT").',
+      error: 'Invalid symbol parameter. Symbol must be a non-empty string with maximum 20 characters (e.g., "BTCUSDT").',
     });
   }
   return null;

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,4 +1,4 @@
 import { z } from 'zod';
 
 /** Reusable schema for validating cryptocurrency symbol strings. */
-export const symbolSchema = z.string().min(1).max(20);
+export const symbolSchema = z.string().trim().min(1).max(20);

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+
+/** Reusable schema for validating cryptocurrency symbol strings. */
+export const symbolSchema = z.string().min(1).max(20);


### PR DESCRIPTION
## Summary
- Created shared `symbolSchema` (`z.string().min(1).max(20)`) in `src/domain/schemas.ts`
- Replaced manual `typeof`/truthiness checks with `symbolSchema.safeParse()` in `priceTools.ts` and `app/api/ai-analysis/[symbol]/route.ts`
- Updated Zod mock in `priceTools.test.ts` to support the chained `.min()/.max()/.safeParse()` API

## Test plan
- [x] `pnpm preflight` passes (typecheck + lint + 28 test suites, 244 passed)
- [ ] Verify AI analysis route returns 400 for invalid/empty symbol
- [ ] Verify price tools return structured error for invalid/empty symbol