### PR TITLE
fix(P4): extract shared HTTP response handler

### DIFF
--- a/src/adapters/binance/BinanceAdapter.ts
+++ b/src/adapters/binance/BinanceAdapter.ts
@@ -2,37 +2,9 @@ import { dedupe, inflightKey } from "@/lib/http/inflight";
 import { get } from "./client";
 import { KlinesSchema, Ticker24hrSchema } from "./schema";
 import type { BinancePort, Candlestick } from "@/ports/BinancePort";
-import { ExternalException } from "@/lib/errors";
+import { handleResponse } from "@/lib/http/handleResponse";
 
 export class BinanceAdapter implements BinancePort {
-  private async buildErrorDetails(
-    res: Response | undefined,
-  ): Promise<{ status: number; statusText?: string; body?: unknown }> {
-    const status = res?.status ?? 500;
-    const details: { status: number; statusText?: string; body?: unknown } = {
-      status,
-    };
-    if (res?.statusText) {
-      details.statusText = res.statusText;
-    }
-    if (res) {
-      try {
-        let errorBody: unknown;
-        try {
-          errorBody = await res.clone().json();
-        } catch {
-          errorBody = await res.clone().text().catch(() => null);
-        }
-        if (errorBody) {
-          details.body = errorBody;
-        }
-      } catch {
-        // Ignore parsing errors
-      }
-    }
-    return details;
-  }
-
   async get24HrStats(symbol: string): Promise<number> {
     const key = inflightKey("binance/ticker24hr", { symbol });
     return dedupe(key, async () => {
@@ -42,17 +14,7 @@ export class BinanceAdapter implements BinancePort {
           next: { revalidate: 30 },
         },
       );
-      if (!res || !res.ok) {
-        const details = await this.buildErrorDetails(res);
-        throw new ExternalException(
-          details.status === 429
-            ? { kind: "RateLimited", details }
-            : { kind: "Unavailable", details },
-          `Binance API error: Status: ${details.status}`,
-        );
-      }
-      const json = await res.json();
-      const parsed = Ticker24hrSchema.parse(json);
+      const parsed = await handleResponse(res, Ticker24hrSchema, "Binance API");
       return parsed.weightedAvgPrice;
     });
   }
@@ -72,18 +34,7 @@ export class BinanceAdapter implements BinancePort {
       const res = await get(`/klines?${query.toString()}`, {
         next: { revalidate: 60 },
       });
-      if (!res || !res.ok) {
-        const details = await this.buildErrorDetails(res);
-        throw new ExternalException(
-          details.status === 429
-            ? { kind: "RateLimited", details }
-            : { kind: "Unavailable", details },
-          `Binance API error: Status: ${details.status}`,
-        );
-      }
-      const json = await res.json();
-      const candles = KlinesSchema.parse(json);
-      return candles;
+      return handleResponse(res, KlinesSchema, "Binance API");
     });
   }
 }

--- a/src/adapters/coincap/CoinCapAdapter.ts
+++ b/src/adapters/coincap/CoinCapAdapter.ts
@@ -3,8 +3,8 @@ import { Asset } from '@/domain/asset';
 import { get } from './client';
 import { ListAssetsResponseSchema } from './schema';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
+import { handleResponse } from '@/lib/http/handleResponse';
 import { logError } from '@/lib/observability';
-import { ExternalException } from '@/lib/errors';
 
 export class CoinCapAdapter implements CoinCapPort {
   async listAssets(params: { limit?: number; offset?: number } = {}): Promise<Asset[]> {
@@ -14,17 +14,7 @@ export class CoinCapAdapter implements CoinCapPort {
       const url = `/assets?limit=${limit}&offset=${offset}`;
       try {
         const res = await get(url, { next: { revalidate: 60 } });
-        if (!res || !res.ok) {
-          const status = res?.status ?? 500;
-          throw new ExternalException(
-            status === 429
-              ? { kind: 'RateLimited', details: { status } }
-              : { kind: 'Unavailable', details: { status } },
-            `CoinCap API error ${status}`,
-          );
-        }
-        const json = await res.json();
-        const parsed = ListAssetsResponseSchema.parse(json);
+        const parsed = await handleResponse(res, ListAssetsResponseSchema, 'CoinCap API');
         return parsed.data;
       } catch (err) {
         logError(err, { adapter: 'CoinCapAdapter', method: 'listAssets', limit, offset });

--- a/src/adapters/news/NewsAdapter.ts
+++ b/src/adapters/news/NewsAdapter.ts
@@ -12,6 +12,7 @@ export class NewsAdapter implements NewsPort {
     const key = inflightKey('news/newsapiai', { symbol, limit });
 
     return dedupe(key, async () => {
+      let url: string | undefined;
       try {
         // Map common crypto symbols to full names for better search results
         const symbolMap: Record<string, string> = {
@@ -41,7 +42,7 @@ export class NewsAdapter implements NewsPort {
           resultType: 'articles',
         });
 
-        const url = `/article/getArticles?${query.toString()}`;
+        url = `/article/getArticles?${query.toString()}`;
         logRequest({ url, method: 'GET' });
 
         let res: Response;
@@ -68,7 +69,7 @@ export class NewsAdapter implements NewsPort {
 
         return articles;
       } catch (err) {
-        logError(err, { symbol, limit });
+        logError(err, { symbol, limit, url });
         // Graceful degradation: return empty array on failure
         return [];
       }

--- a/src/adapters/news/NewsAdapter.ts
+++ b/src/adapters/news/NewsAdapter.ts
@@ -3,8 +3,8 @@ import { NewsArticle } from '@/domain/newsArticle';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
 import { get } from './client';
 import { NewsAPIaiResponseSchema } from './schema';
+import { handleResponse } from '@/lib/http/handleResponse';
 import { logRequest, logError } from '@/lib/observability';
-import { ExternalException } from '@/lib/errors';
 
 export class NewsAdapter implements NewsPort {
   async fetchNews(params: { symbol: string; limit?: number }): Promise<NewsArticle[]> {
@@ -52,21 +52,7 @@ export class NewsAdapter implements NewsPort {
           throw fetchError;
         }
 
-        if (!res || !res.ok) {
-          const status = res?.status ?? 500;
-          const errorText = await res?.text?.();
-          const error = new ExternalException(
-            status === 429
-              ? { kind: 'RateLimited', details: { status, errorText } }
-              : { kind: 'Unavailable', details: { status, errorText } },
-            `NewsAPI.ai error ${status}`,
-          );
-          logError(error, { symbol, limit, url });
-          throw error;
-        }
-
-        const json = await res.json();
-        const parsed = NewsAPIaiResponseSchema.parse(json);
+        const parsed = await handleResponse(res, NewsAPIaiResponseSchema, 'NewsAPI.ai');
 
         // Transform NewsAPI.ai response to our domain model
         const articles: NewsArticle[] = parsed.articles.results.map((article) => ({

--- a/src/lib/http/handleResponse.ts
+++ b/src/lib/http/handleResponse.ts
@@ -28,8 +28,8 @@ export async function handleResponse<T>(
 
     throw new ExternalException(
       status === 429
-        ? { kind: 'RateLimited', details: { status, body } }
-        : { kind: 'Unavailable', details: { status, body } },
+        ? { kind: 'RateLimited', details: { status, statusText: res?.statusText, body } }
+        : { kind: 'Unavailable', details: { status, statusText: res?.statusText, body } },
       `${label} error ${status}`,
     );
   }

--- a/src/lib/http/handleResponse.ts
+++ b/src/lib/http/handleResponse.ts
@@ -1,0 +1,39 @@
+import type { ZodType, ZodTypeDef } from 'zod';
+import { ExternalException } from '@/lib/errors';
+
+/**
+ * Shared HTTP response handler: check status → parse JSON → validate schema.
+ * Throws ExternalException on non-ok responses with status and error body context.
+ */
+export async function handleResponse<T>(
+  res: Response | null | undefined,
+  schema: ZodType<T, ZodTypeDef, unknown>,
+  label: string,
+): Promise<T> {
+  if (!res || !res.ok) {
+    const status = res?.status ?? 500;
+
+    let body: unknown;
+    if (res) {
+      try {
+        body = await res.clone().json();
+      } catch {
+        try {
+          body = await res.clone().text();
+        } catch {
+          // ignore — body stays undefined
+        }
+      }
+    }
+
+    throw new ExternalException(
+      status === 429
+        ? { kind: 'RateLimited', details: { status, body } }
+        : { kind: 'Unavailable', details: { status, body } },
+      `${label} error ${status}`,
+    );
+  }
+
+  const json = await res.json();
+  return schema.parse(json);
+}


### PR DESCRIPTION
## Summary

- Extracted a shared `handleResponse<T>(res, schema, label)` utility into `src/lib/http/handleResponse.ts` that encapsulates the `check status → parse JSON → validate Zod schema` pipeline
- Refactored CoinCapAdapter, BinanceAdapter, and NewsAdapter to use the shared handler, removing duplicated inline `!res.ok` checks, JSON parsing, and schema validation boilerplate
- Removed the 30-line `buildErrorDetails` private helper from BinanceAdapter (now handled by the shared utility)

## Test plan

- [x] `pnpm preflight` passes (typecheck + lint + 244 tests)
- [ ] Verify adapters still return correct data in dev against live APIs
- [ ] Verify error responses (429, 500) still produce typed `ExternalException` with status context