### PR TITLE
fix(MA3): extract adapter config constants

### DIFF
--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { fetchAssets } from '@/lib/data/assets';
 import { logError } from '@/lib/observability';
 import { isExternalException } from '@/lib/errors';
+import { COINCAP_DEFAULT_LIMIT, COINCAP_REVALIDATE_S } from '@/lib/config';
 
 export async function GET(req: Request): Promise<Response> {
   const { searchParams } = new URL(req.url);
-  const limit = Number(searchParams.get('limit') ?? '19');
+  const limit = Number(searchParams.get('limit') ?? String(COINCAP_DEFAULT_LIMIT));
   const offset = Number(searchParams.get('offset') ?? '0');
 
   try {
@@ -21,5 +22,5 @@ export async function GET(req: Request): Promise<Response> {
   }
 }
 
-export const revalidate = 60;
+export const revalidate = COINCAP_REVALIDATE_S;
 export const runtime = 'nodejs';

--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { fetchAssets } from '@/lib/data/assets';
 import { logError } from '@/lib/observability';
 import { isExternalException } from '@/lib/errors';
-import { COINCAP_DEFAULT_LIMIT, COINCAP_REVALIDATE_S } from '@/lib/config';
+import { COINCAP_DEFAULT_LIMIT } from '@/lib/config';
 
 export async function GET(req: Request): Promise<Response> {
   const { searchParams } = new URL(req.url);
@@ -22,5 +22,6 @@ export async function GET(req: Request): Promise<Response> {
   }
 }
 
-export const revalidate = COINCAP_REVALIDATE_S;
+// Must be a static literal for Next.js segment config — matches COINCAP_REVALIDATE_S
+export const revalidate = 60;
 export const runtime = 'nodejs';

--- a/src/adapters/binance/BinanceAdapter.ts
+++ b/src/adapters/binance/BinanceAdapter.ts
@@ -3,6 +3,7 @@ import { get } from "./client";
 import { KlinesSchema, Ticker24hrSchema } from "./schema";
 import type { BinancePort, Candlestick } from "@/ports/BinancePort";
 import { handleResponse } from "@/lib/http/handleResponse";
+import { BINANCE_TICKER_REVALIDATE_S, BINANCE_CANDLES_REVALIDATE_S } from "@/lib/config";
 
 export class BinanceAdapter implements BinancePort {
   async get24HrStats(symbol: string): Promise<number> {
@@ -11,7 +12,7 @@ export class BinanceAdapter implements BinancePort {
       const res = await get(
         `/ticker/24hr?symbol=${encodeURIComponent(symbol)}`,
         {
-          next: { revalidate: 30 },
+          next: { revalidate: BINANCE_TICKER_REVALIDATE_S },
         },
       );
       const parsed = await handleResponse(res, Ticker24hrSchema, "Binance API");
@@ -32,7 +33,7 @@ export class BinanceAdapter implements BinancePort {
       const query = new URLSearchParams({ symbol, interval: "1d" });
       if (typeof limit === "number") query.set("limit", String(limit));
       const res = await get(`/klines?${query.toString()}`, {
-        next: { revalidate: 60 },
+        next: { revalidate: BINANCE_CANDLES_REVALIDATE_S },
       });
       return handleResponse(res, KlinesSchema, "Binance API");
     });

--- a/src/adapters/binance/client.ts
+++ b/src/adapters/binance/client.ts
@@ -1,6 +1,7 @@
 import { fetchWithRetry } from '@/lib/http/fetcher';
 import { logRequest } from '@/lib/observability';
 import { getEnv } from '@/lib/env';
+import { BINANCE_TIMEOUT_MS } from '@/lib/config';
 
 const { BINANCE_BASE_URL } = getEnv();
 const BASE_URL = BINANCE_BASE_URL ?? 'https://api.binance.com/api/v3';
@@ -19,7 +20,7 @@ export async function get(
   return fetchWithRetry(
     url,
     { next, headers },
-    { timeoutMs: 10_000 },
+    { timeoutMs: BINANCE_TIMEOUT_MS },
   );
 }
 

--- a/src/adapters/coincap/CoinCapAdapter.ts
+++ b/src/adapters/coincap/CoinCapAdapter.ts
@@ -5,15 +5,16 @@ import { ListAssetsResponseSchema } from './schema';
 import { dedupe, inflightKey } from '@/lib/http/inflight';
 import { handleResponse } from '@/lib/http/handleResponse';
 import { logError } from '@/lib/observability';
+import { COINCAP_DEFAULT_LIMIT, COINCAP_REVALIDATE_S } from '@/lib/config';
 
 export class CoinCapAdapter implements CoinCapPort {
   async listAssets(params: { limit?: number; offset?: number } = {}): Promise<Asset[]> {
-    const { limit = 19, offset = 0 } = params;
+    const { limit = COINCAP_DEFAULT_LIMIT, offset = 0 } = params;
     const key = inflightKey('coincap/assets', { limit, offset });
     return dedupe(key, async () => {
       const url = `/assets?limit=${limit}&offset=${offset}`;
       try {
-        const res = await get(url, { next: { revalidate: 60 } });
+        const res = await get(url, { next: { revalidate: COINCAP_REVALIDATE_S } });
         const parsed = await handleResponse(res, ListAssetsResponseSchema, 'CoinCap API');
         return parsed.data;
       } catch (err) {

--- a/src/adapters/coincap/client.ts
+++ b/src/adapters/coincap/client.ts
@@ -1,6 +1,7 @@
 import { fetchWithRetry } from '@/lib/http/fetcher';
 import { logRequest } from '@/lib/observability';
 import { getEnv } from '@/lib/env';
+import { COINCAP_TIMEOUT_MS } from '@/lib/config';
 
 const { COINCAP_BASE_URL } = getEnv();
 const BASE_URL = COINCAP_BASE_URL ?? 'https://rest.coincap.io/v3';
@@ -12,6 +13,6 @@ export async function get(path: string, { next }: { next?: NextFetchRequestConfi
   return fetchWithRetry(
     url,
     { next, headers: { Authorization: `Bearer ${COINCAP_API_KEY ?? ''}` } },
-    { timeoutMs: 10_000 }
+    { timeoutMs: COINCAP_TIMEOUT_MS }
   );
 }

--- a/src/adapters/langchain/LangChainAiAdapter.ts
+++ b/src/adapters/langchain/LangChainAiAdapter.ts
@@ -6,6 +6,7 @@ import { getEnv } from "@/lib/env";
 import { logRequest, logError } from "@/lib/observability";
 import { ExternalException } from "@/lib/errors";
 import { toBinancePair } from "@/lib/symbolMeta";
+import { AI_LLM_TEMPERATURE, AI_NEWS_LIMIT, AI_PRICE_HISTORY_DAYS } from "@/lib/config";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
 import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
@@ -167,7 +168,7 @@ export class LangChainAiAdapter implements AiAnalysisPort {
     this.model = new ChatOpenAI({
       model: "gpt-5.1",
       apiKey: env.OPENAI_API_KEY,
-      temperature: 0.7,
+      temperature: AI_LLM_TEMPERATURE,
     });
 
     const { getPriceHistoryTool, getVWAPTool } = createPriceTools({
@@ -209,9 +210,9 @@ Do not provide financial advice. Focus on data-driven observations.`;
       logRequest({ url: `openai/chat (${symbol})`, method: 'POST' });
 
       const [priceHistoryResult, vwapResult, newsResult] = await Promise.allSettled([
-        this.getPriceHistoryTool.invoke({ symbol: binanceSymbol, limit: 14 }),
+        this.getPriceHistoryTool.invoke({ symbol: binanceSymbol, limit: AI_PRICE_HISTORY_DAYS }),
         this.getVWAPTool.invoke({ symbol: binanceSymbol }),
-        this.getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: 5 }),
+        this.getNewsArticlesTool.invoke({ symbol: symbol.toUpperCase(), limit: AI_NEWS_LIMIT }),
       ]);
 
       // Parse and format tool results for LLM consumption

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -2,6 +2,7 @@ import { tool } from 'langchain';
 import { z } from 'zod';
 import { NewsPort } from '@/ports/NewsPort';
 import { symbolSchema } from '@/domain/schemas';
+import { NEWS_DEFAULT_LIMIT } from '@/lib/config';
 
 export interface NewsToolDeps {
   newsPort: NewsPort;
@@ -59,7 +60,7 @@ export function createNewsTool(deps: NewsToolDeps) {
         }
 
         const normalizedSymbol = symbol.trim().toUpperCase();
-        const requestLimit = limit ?? 5;
+        const requestLimit = limit ?? NEWS_DEFAULT_LIMIT;
         const articles = await deps.newsPort.fetchNews({
           symbol: normalizedSymbol,
           limit: requestLimit,

--- a/src/adapters/langchain/tools/newsTool.ts
+++ b/src/adapters/langchain/tools/newsTool.ts
@@ -89,7 +89,7 @@ export function createNewsTool(deps: NewsToolDeps) {
     {
       name: 'get_news_articles',
       description:
-        'Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default 5, max 10). Returns a JSON object with success, symbol, count, and a data array of news articles.',
+        `Fetches recent cryptocurrency news articles for sentiment analysis and market context. Input: symbol (e.g., BTC, ETH), optional limit (default ${NEWS_DEFAULT_LIMIT}, max 10). Returns a JSON object with success, symbol, count, and a data array of news articles.`,
       schema: z.object({
         symbol: z.string().describe('The cryptocurrency symbol (e.g., BTC, ETH).'),
         limit: z
@@ -97,7 +97,7 @@ export function createNewsTool(deps: NewsToolDeps) {
           .min(1)
           .max(10)
           .optional()
-          .describe('Number of articles to fetch (default 5, max 10).'),
+          .describe(`Number of articles to fetch (default ${NEWS_DEFAULT_LIMIT}, max 10).`),
       }),
     }
   );

--- a/src/adapters/news/NewsAdapter.ts
+++ b/src/adapters/news/NewsAdapter.ts
@@ -6,10 +6,11 @@ import { NewsAPIaiResponseSchema } from './schema';
 import { handleResponse } from '@/lib/http/handleResponse';
 import { logRequest, logError } from '@/lib/observability';
 import { toDisplayName } from '@/lib/symbolMeta';
+import { NEWS_DEFAULT_LIMIT, NEWS_REVALIDATE_S } from '@/lib/config';
 
 export class NewsAdapter implements NewsPort {
   async fetchNews(params: { symbol: string; limit?: number }): Promise<NewsArticle[]> {
-    const { symbol, limit = 5 } = params;
+    const { symbol, limit = NEWS_DEFAULT_LIMIT } = params;
     const key = inflightKey('news/newsapiai', { symbol, limit });
 
     return dedupe(key, async () => {
@@ -32,7 +33,7 @@ export class NewsAdapter implements NewsPort {
 
         let res: Response;
         try {
-          res = await get(url, { next: { revalidate: 300 } as never });
+          res = await get(url, { next: { revalidate: NEWS_REVALIDATE_S } as never });
         } catch (fetchError) {
           logError(fetchError, { symbol, limit, stage: 'fetch' });
           throw fetchError;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,7 +5,7 @@
 // -- CoinCap ------------------------------------------------------------------
 export const COINCAP_REVALIDATE_S = 60;
 export const COINCAP_TIMEOUT_MS = 10_000;
-export const COINCAP_DEFAULT_LIMIT = 19; // 5× whitelist multiplier for filtered results
+export const COINCAP_DEFAULT_LIMIT = 19; // Default number of assets to request from CoinCap
 
 // -- Binance ------------------------------------------------------------------
 export const BINANCE_TICKER_REVALIDATE_S = 30;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// Centralized adapter configuration constants
+// ---------------------------------------------------------------------------
+
+// -- CoinCap ------------------------------------------------------------------
+export const COINCAP_REVALIDATE_S = 60;
+export const COINCAP_TIMEOUT_MS = 10_000;
+export const COINCAP_DEFAULT_LIMIT = 19; // 5× whitelist multiplier for filtered results
+
+// -- Binance ------------------------------------------------------------------
+export const BINANCE_TICKER_REVALIDATE_S = 30;
+export const BINANCE_CANDLES_REVALIDATE_S = 60;
+export const BINANCE_TIMEOUT_MS = 10_000;
+
+// -- News (NewsAPI.ai) --------------------------------------------------------
+export const NEWS_REVALIDATE_S = 300;
+export const NEWS_DEFAULT_LIMIT = 5;
+
+// -- AI / LangChain -----------------------------------------------------------
+export const AI_PRICE_HISTORY_DAYS = 14;
+export const AI_NEWS_LIMIT = 5;
+export const AI_LLM_TEMPERATURE = 0.7;


### PR DESCRIPTION
## Summary

Implements task **MA3**: Extract adapter config constants

**Type:** fix
**Complexity:** S

## What was done

- Created `src/lib/config.ts` with named constants grouped by adapter (CoinCap, Binance, News, AI/LangChain) covering revalidation TTLs, HTTP timeouts, default limits, and LLM temperature
- Replaced all 13 magic numbers across 8 files (4 adapters, 2 clients, 1 route handler, 1 tool) with imports from the centralized config module
- Pure refactor — all values identical, no behavioral change

## Done When

No magic numeric literals remain in adapter files, client files, or route handlers for revalidation times, timeouts, or default limits. All values are imported from `src/lib/config.ts`. `pnpm preflight` passes with zero warnings.