### PR TITLE
fix(MA4): standardize API error responses via shared builder

### DIFF
--- a/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
+++ b/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
@@ -67,6 +67,6 @@ describe('POST /api/ai-analysis/[symbol]', () => {
     const res = await POST(req, ctx);
     expect(res.status).toBe(502);
     const body = await res.json();
-    expect(body.error).toBe('Something broke');
+    expect(body.error).toBe('Upstream unavailable');
   });
 });

--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
-import { logError } from '@/lib/observability';
-import { isExternalException } from '@/lib/errors';
+import { apiErrorResponse } from '@/lib/http/apiErrorResponse';
 import { symbolSchema } from '@/domain/schemas';
 
 export async function POST(
@@ -24,18 +23,7 @@ export async function POST(
 
     return NextResponse.json({ analysis }, { status: 200 });
   } catch (e) {
-    logError(e, { route: 'POST /api/ai-analysis', symbol });
-    if (isExternalException(e)) {
-      const status = e.kind === 'RateLimited' ? 429 : e.kind === 'InvalidRequest' ? 400 : 502;
-      return NextResponse.json(
-        { error: e.message },
-        { status }
-      );
-    }
-    return NextResponse.json(
-      { error: e instanceof Error ? e.message : 'Failed to generate analysis' },
-      { status: 502 }
-    );
+    return apiErrorResponse(e, { route: 'POST /api/ai-analysis', symbol });
   }
 }
 

--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchAssets } from '@/lib/data/assets';
-import { logError } from '@/lib/observability';
-import { isExternalException } from '@/lib/errors';
+import { apiErrorResponse } from '@/lib/http/apiErrorResponse';
 import { COINCAP_DEFAULT_LIMIT } from '@/lib/config';
 
 export async function GET(req: Request): Promise<Response> {
@@ -13,12 +12,7 @@ export async function GET(req: Request): Promise<Response> {
     const assets = await fetchAssets({ limit, offset });
     return NextResponse.json(assets, { status: 200 });
   } catch (e) {
-    logError(e, { route: 'GET /api/assets', limit, offset });
-    if (isExternalException(e)) {
-      const status = e.kind === 'RateLimited' ? 429 : e.kind === 'InvalidRequest' ? 400 : 502;
-      return NextResponse.json({ error: e.message }, { status });
-    }
-    return NextResponse.json({ error: 'Upstream unavailable' }, { status: 502 });
+    return apiErrorResponse(e, { route: 'GET /api/assets', limit, offset });
   }
 }
 

--- a/src/lib/http/apiErrorResponse.ts
+++ b/src/lib/http/apiErrorResponse.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { isExternalException } from '@/lib/errors';
+import { logError } from '@/lib/observability';
+
+/**
+ * Shared API route error handler: log, map to HTTP status, return JSON response.
+ * Replaces duplicated catch-block logic in API routes.
+ */
+export function apiErrorResponse(
+  error: unknown,
+  context: Record<string, unknown>,
+): NextResponse {
+  logError(error, context);
+
+  if (isExternalException(error)) {
+    const status =
+      error.kind === 'RateLimited'
+        ? 429
+        : error.kind === 'InvalidRequest'
+          ? 400
+          : 502;
+    return NextResponse.json({ error: error.message }, { status });
+  }
+
+  return NextResponse.json({ error: 'Upstream unavailable' }, { status: 502 });
+}


### PR DESCRIPTION
## Summary
- Extract `apiErrorResponse()` in `src/lib/http/apiErrorResponse.ts` to centralize error-to-HTTP-response mapping (status codes, logging, JSON body)
- Migrate `app/api/assets/route.ts` and `app/api/ai-analysis/[symbol]/route.ts` to use the shared builder
- Standardize non-ExternalException errors to consistent `"Upstream unavailable"` message across all routes

## Test plan
- [x] `pnpm preflight` passes (typecheck + lint + tests)
- [x] Existing route tests updated and passing
- [x] Error status mapping preserved: RateLimited→429, InvalidRequest→400, default→502