### PR TITLE
fix(PA1,PA2): document phantom port-adapter pairs as intentional

### DIFF
--- a/src/ports/MarketDataPort.ts
+++ b/src/ports/MarketDataPort.ts
@@ -1,5 +1,12 @@
 import { MarketData } from '@/domain/marketData';
 
+/**
+ * Port for fetching per-symbol market data (market cap, supply, VWAP, dominance).
+ *
+ * Currently backed by {@link MockMarketDataAdapter} which returns deterministic
+ * data for UI development. A real adapter (e.g. CoinGecko or CoinCap v3) can be
+ * swapped in via the composition root without changing downstream use cases.
+ */
 export interface MarketDataPort {
   getBySymbol(symbol: string): Promise<MarketData>;
 }

--- a/src/ports/TradingActivityPort.ts
+++ b/src/ports/TradingActivityPort.ts
@@ -1,5 +1,12 @@
 import { TradingActivity } from '@/domain/tradingActivity';
 
+/**
+ * Port for fetching per-symbol trading activity (volume, liquidity, exchanges, CEX/DEX split).
+ *
+ * Currently backed by {@link MockTradingActivityAdapter} which returns deterministic
+ * data for UI development. A real adapter (e.g. CoinGecko or aggregated exchange APIs)
+ * can be swapped in via the composition root without changing downstream use cases.
+ */
 export interface TradingActivityPort {
   getBySymbol(symbol: string): Promise<TradingActivity>;
 }


### PR DESCRIPTION
## Summary
- MarketDataPort and TradingActivityPort only have mock adapter implementations
- BinanceAdapter lacks the data needed for real implementations (market cap, supply, dominance, exchange splits)
- Added JSDoc to both ports documenting that mock-only is intentional for UI development
- Ports remain as clean architecture placeholders for future real adapter integration

## Test plan
- [x] `pnpm preflight` passes
- [x] No behavioral changes — documentation only