### PR TITLE
fix(PA3,PA4): document passthrough usecases as intentional placeholders

### DIFF
--- a/src/usecases/getMarketData.ts
+++ b/src/usecases/getMarketData.ts
@@ -1,6 +1,12 @@
 import { MarketData } from '@/domain/marketData';
 import { MarketDataPort } from '@/ports/MarketDataPort';
 
+/**
+ * Usecase for fetching market data by symbol.
+ *
+ * Currently a passthrough to the port — business logic (validation, caching,
+ * enrichment) will be added here when a real adapter replaces the mock.
+ */
 export async function getMarketData(
   deps: { marketData: MarketDataPort },
   symbol: string,

--- a/src/usecases/getTradingActivity.ts
+++ b/src/usecases/getTradingActivity.ts
@@ -5,6 +5,12 @@ type Dependencies = {
   tradingActivity: TradingActivityPort;
 };
 
+/**
+ * Usecase for fetching trading activity by symbol.
+ *
+ * Currently a passthrough to the port — business logic (validation, caching,
+ * enrichment) will be added here when a real adapter replaces the mock.
+ */
 export async function getTradingActivity(
   deps: Dependencies,
   symbol: string


### PR DESCRIPTION
## Summary
- `getMarketData` and `getTradingActivity` usecases are 1:1 passthroughs to their ports
- These exist for architectural consistency with the clean architecture layer structure
- Added JSDoc documenting them as intentional placeholders for future business logic

## Test plan
- [x] `pnpm preflight` passes
- [x] No behavioral changes — documentation only