### PR TITLE
chore: add wf workflow scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ yarn-error.log*
 .vscode/
 .claude/
 .cursor/
+
+# wf plugin
+wf.config.js
+.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ yarn-error.log*
 # wf plugin
 wf.config.js
 .tmp/
+docs/wf-plans/

--- a/docs/wf-plans/INDEX.md
+++ b/docs/wf-plans/INDEX.md
@@ -1,0 +1,4 @@
+# Task Index
+
+| Status | ID | Type | Title | Complexity | Resolution | Folder |
+|--------|----|------|-------|------------|------------|--------|

--- a/docs/wf-plans/INDEX.md
+++ b/docs/wf-plans/INDEX.md
@@ -1,4 +1,0 @@
-# Task Index
-
-| Status | ID | Type | Title | Complexity | Resolution | Folder |
-|--------|----|------|-------|------------|------------|--------|


### PR DESCRIPTION
Adds the `/wf` dev-workflow scaffolding to the repo — gitignore-only, no tracked workflow artifacts.

- Ignore `wf.config.js` (machine-local config), `.tmp/` (workflow breadcrumbs), and `docs/wf-plans/` (per-task plan folders) in `.gitignore`

No source or behavior changes.