### PR TITLE
feat(NEU-786): Real end-to-end streaming via the AI SDK (adapter → route → card)

### DIFF
--- a/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
+++ b/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
@@ -5,9 +5,11 @@ import { ExternalException } from '@/lib/errors';
 jest.mock('@/lib/data/aiAnalysisServer');
 
 import { POST } from '../route';
-import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
+import { analyzeAssetStream } from '@/lib/data/aiAnalysisServer';
 
-const mockAnalyzeAsset = analyzeAsset as jest.MockedFunction<typeof analyzeAsset>;
+const mockAnalyzeAssetStream = analyzeAssetStream as jest.MockedFunction<
+  typeof analyzeAssetStream
+>;
 
 function makeRequest(symbol: string) {
   return [
@@ -16,57 +18,149 @@ function makeRequest(symbol: string) {
   ] as const;
 }
 
+/** An async iterable that yields the given chunks then completes. */
+function iterableOf(chunks: string[]): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) yield chunk;
+    },
+  };
+}
+
+/** An async iterable whose first `next()` rejects (pre-stream failure). */
+function rejectingIterable(error: unknown): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => Promise.reject(error),
+        return: () => Promise.resolve({ done: true as const, value: undefined }),
+      };
+    },
+  };
+}
+
+/** Yields one chunk, then rejects on the second `next()` (mid-stream failure). */
+function failAfterFirst(first: string, error: unknown): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]() {
+      let sent = false;
+      return {
+        next: () =>
+          sent
+            ? Promise.reject(error)
+            : ((sent = true), Promise.resolve({ done: false as const, value: first })),
+        return: () => Promise.resolve({ done: true as const, value: undefined }),
+      };
+    },
+  };
+}
+
 describe('POST /api/ai-analysis/[symbol]', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('returns 200 with analysis on success', async () => {
-    mockAnalyzeAsset.mockResolvedValue('Bullish momentum...');
+  it('streams a text/plain response that concatenates the chunks', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(iterableOf(['Bullish ', 'momentum ', 'building.']));
     const [req, ctx] = makeRequest('BTC');
     const res = await POST(req, ctx);
+
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.analysis).toBe('Bullish momentum...');
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(await res.text()).toBe('Bullish momentum building.');
   });
 
-  it('returns 429 for RateLimited errors', async () => {
-    mockAnalyzeAsset.mockRejectedValue(
-      new ExternalException({ kind: 'RateLimited' }, 'Too many requests'),
-    );
+  it('returns an empty 200 stream when the analysis produces no chunks', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(iterableOf([]));
     const [req, ctx] = makeRequest('BTC');
     const res = await POST(req, ctx);
-    expect(res.status).toBe(429);
-    const body = await res.json();
-    expect(body.error).toBe('Too many requests');
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
   });
 
-  it('returns 400 for InvalidRequest errors', async () => {
-    mockAnalyzeAsset.mockRejectedValue(
-      new ExternalException({ kind: 'InvalidRequest' }, 'Missing API key'),
-    );
+  it('stops generation by calling iterator.return when the client cancels', async () => {
+    const returnSpy = jest
+      .fn()
+      .mockResolvedValue({ done: true as const, value: undefined });
+    let count = 0;
+    const iterable: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => Promise.resolve({ done: false as const, value: `chunk${count++}` }),
+          return: returnSpy,
+        };
+      },
+    };
+    mockAnalyzeAssetStream.mockReturnValue(iterable);
+
     const [req, ctx] = makeRequest('BTC');
     const res = await POST(req, ctx);
+    await res.body!.cancel();
+
+    expect(returnSpy).toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid symbol without invoking the stream', async () => {
+    const [req, ctx] = makeRequest('A'.repeat(21));
+    const res = await POST(req, ctx);
+
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe('Missing API key');
+    expect(body.error).toBe('Invalid symbol parameter');
+    expect(mockAnalyzeAssetStream).not.toHaveBeenCalled();
   });
 
-  it('returns 502 for Unavailable errors', async () => {
-    mockAnalyzeAsset.mockRejectedValue(
-      new ExternalException({ kind: 'Unavailable' }, 'OpenAI down'),
+  it('returns 429 for RateLimited errors thrown before the first chunk', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(
+      rejectingIterable(new ExternalException({ kind: 'RateLimited' }, 'Too many requests')),
     );
     const [req, ctx] = makeRequest('BTC');
     const res = await POST(req, ctx);
-    expect(res.status).toBe(502);
-    const body = await res.json();
-    expect(body.error).toBe('OpenAI down');
+
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toBe('Too many requests');
   });
 
-  it('returns 502 for untyped errors', async () => {
-    mockAnalyzeAsset.mockRejectedValue(new Error('Something broke'));
+  it('returns 400 for InvalidRequest errors thrown before the first chunk', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(
+      rejectingIterable(new ExternalException({ kind: 'InvalidRequest' }, 'Missing API key')),
+    );
     const [req, ctx] = makeRequest('BTC');
     const res = await POST(req, ctx);
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Missing API key');
+  });
+
+  it('returns 502 for Unavailable errors thrown before the first chunk', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(
+      rejectingIterable(new ExternalException({ kind: 'Unavailable' }, 'OpenAI down')),
+    );
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+
     expect(res.status).toBe(502);
-    const body = await res.json();
-    expect(body.error).toBe('Upstream unavailable');
+    expect((await res.json()).error).toBe('OpenAI down');
+  });
+
+  it('returns 502 for untyped errors thrown before the first chunk', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(rejectingIterable(new Error('Something broke')));
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe('Upstream unavailable');
+  });
+
+  it('surfaces a mid-stream error by failing the response body', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(
+      failAfterFirst('Partial analysis ', new Error('stream blew up')),
+    );
+    const [req, ctx] = makeRequest('BTC');
+    const res = await POST(req, ctx);
+
+    // Headers were already sent with the first chunk, so the status stays 200
+    // but reading the full body rejects rather than completing silently.
+    expect(res.status).toBe(200);
+    await expect(res.text()).rejects.toThrow();
   });
 });

--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { analyzeAsset } from '@/lib/data/aiAnalysisServer';
+import { analyzeAssetStream } from '@/lib/data/aiAnalysisServer';
 import { apiErrorResponse } from '@/lib/http/apiErrorResponse';
+import { logError } from '@/lib/observability';
 import { symbolSchema } from '@/domain/schemas';
 
 export async function POST(
@@ -19,9 +20,58 @@ export async function POST(
       );
     }
 
-    const analysis = await analyzeAsset(symbol);
+    const iterator = analyzeAssetStream(symbol)[Symbol.asyncIterator]();
 
-    return NextResponse.json({ analysis }, { status: 200 });
+    // Pull the first chunk eagerly: a pre-stream failure (missing config, an
+    // invalid request, or a first-token upstream error) is wrapped as an
+    // ExternalException here, so we can still map it to a proper JSON HTTP
+    // status before any streaming headers are sent.
+    const first = await iterator.next();
+
+    const encoder = new TextEncoder();
+    const symbolForLog = symbol;
+    let cancelled = false;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (first.done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(first.value));
+      },
+      async pull(controller) {
+        try {
+          const { value, done } = await iterator.next();
+          if (cancelled) return;
+          if (done) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(encoder.encode(value));
+        } catch (e) {
+          if (cancelled) return;
+          // Headers are already sent, so the status code can no longer change.
+          // Error the stream instead — the client reader rejects rather than
+          // receiving a silently truncated analysis.
+          logError(e, { route: 'POST /api/ai-analysis (stream)', symbol: symbolForLog });
+          controller.error(e);
+        }
+      },
+      async cancel() {
+        // Client disconnected — stop generation and release the upstream call.
+        cancelled = true;
+        await iterator.return?.();
+      },
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
   } catch (e) {
     return apiErrorResponse(e, { route: 'POST /api/ai-analysis', symbol });
   }

--- a/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
+++ b/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// react-markdown ships as ESM and is not transformed by Jest; mock it with a
+// passthrough that renders the raw markdown text so we can assert on content.
+jest.mock("react-markdown", () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <>{children}</>,
+}));
+
+import { AiAnalysisSection } from "../ai-analysis-section";
+
+/** Build a fetch Response-like object whose body streams the given chunks. */
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+  } as unknown as Response;
+}
+
+/** A streaming Response that emits one chunk then errors the stream. */
+function midStreamErrorResponse(first: string): Response {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(first));
+        controller.error(new Error("stream blew up"));
+      },
+    }),
+  } as unknown as Response;
+}
+
+describe("AiAnalysisSection", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("renders the empty state with a Generate button", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+
+    expect(screen.getByText("AI Analysis")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("streams the analysis and then reveals it with a Regenerate button", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        // Leading empty chunk exercises the "skip empty chunk" path.
+        streamResponse(["", "## Market Bias\n", "Bullish ", "momentum building."]),
+      );
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+
+    // Progressive content is rendered from the stream.
+    expect(await screen.findByText(/Bullish momentum building\./i)).toBeInTheDocument();
+    // On completion the Regenerate CTA appears.
+    expect(
+      await screen.findByRole("button", { name: /regenerate analysis/i }),
+    ).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/ai-analysis/BTC",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("shows the error state when the response is not ok", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Too many requests" }),
+    } as unknown as Response);
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+
+    expect(await screen.findByText("Too many requests")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the error state when the stream fails mid-way", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(midStreamErrorResponse("Partial analysis "));
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/details/[symbol]/_components/ai-analysis-section.tsx
+++ b/app/details/[symbol]/_components/ai-analysis-section.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/card";
 import { ActionButton } from "@/components/ui/action-button";
 import { BrainCircuit } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { Components } from "react-markdown";
 import ShimmerCard from "@/components/ui/shimmer-card";
 import Markdown from "react-markdown";
 
@@ -19,42 +20,140 @@ interface AiAnalysisSectionProps {
   symbol: string;
 }
 
+type Status = "idle" | "loading" | "streaming" | "complete" | "error";
+
+// Shared markdown renderer overrides — used by both the streaming and the
+// final reveal states so partial and complete analysis render identically.
+const markdownComponents: Components = {
+  h1: ({ children }) => (
+    <h1 className="text-xl font-bold text-foreground mt-0 mb-3">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="text-lg font-semibold text-foreground mt-4 mb-2 first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-base font-semibold text-foreground mt-3 mb-2 first:mt-0">
+      {children}
+    </h3>
+  ),
+  p: ({ children }) => (
+    <p className="text-sm text-foreground/90 mb-3 leading-relaxed break-words">
+      {children}
+    </p>
+  ),
+  strong: ({ children }) => (
+    <strong className="font-semibold text-foreground">{children}</strong>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc list-inside mb-3 space-y-1.5">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal ml-4 mb-3 space-y-2">{children}</ol>
+  ),
+  li: ({ children }) => (
+    <li className="text-sm text-foreground/90 leading-relaxed break-words">
+      {children}
+    </li>
+  ),
+  code: ({ children }) => (
+    <code className="bg-muted/40 px-1.5 py-0.5 rounded text-xs font-mono text-foreground break-words">
+      {children}
+    </code>
+  ),
+};
+
+function AnalysisMarkdown({ children }: { children: string }) {
+  return (
+    <div className="flex-1 prose prose-invert prose-sm max-w-none wrap-anywhere min-w-0">
+      <Markdown components={markdownComponents}>{children}</Markdown>
+    </div>
+  );
+}
+
 export function AiAnalysisSection({
   name,
   symbol,
 }: AiAnalysisSectionProps) {
-  const [analysis, setAnalysis] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight stream when the component unmounts (e.g. the user
+  // navigates away mid-stream) so the server stops generating.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
 
   const handleGenerate = async () => {
-    setLoading(true);
+    // Cancel a previous in-flight request (e.g. a rapid regenerate).
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus("loading");
+    setText("");
     setError(null);
 
     try {
       const response = await fetch(`/api/ai-analysis/${symbol}`, {
         method: "POST",
+        signal: controller.signal,
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Failed to generate analysis");
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || "Failed to generate analysis");
       }
 
-      const data = await response.json();
-      setAnalysis(data.analysis);
+      if (!response.body) {
+        throw new Error("No response stream");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let accumulated = "";
+      let started = false;
+
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        if (!chunk) continue;
+        accumulated += chunk;
+        if (!started) {
+          started = true;
+          setStatus("streaming");
+        }
+        setText(accumulated);
+      }
+
+      // Flush any buffered multi-byte character left in the decoder.
+      const tail = decoder.decode();
+      if (tail) {
+        accumulated += tail;
+        setText(accumulated);
+      }
+
+      setStatus("complete");
     } catch (err) {
+      // A deliberate abort (unmount / regenerate) is not an error to surface.
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return;
+      }
       setError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
-      setLoading(false);
+      setStatus("error");
     }
   };
 
-  if (loading) {
+  if (status === "loading") {
     return <ShimmerCard className="min-w-[220px]" />;
   }
 
-  if (analysis) {
+  if (status === "streaming" || status === "complete") {
+    const isStreaming = status === "streaming";
     return (
       <Card className="glassmorphic min-w-[220px]">
         <CardHeader>
@@ -78,67 +177,26 @@ export function AiAnalysisSection({
             </div>
 
             {/* Analysis Content */}
-            <div className="flex-1 prose prose-invert prose-sm max-w-none wrap-anywhere min-w-0">
-              <Markdown
-                components={{
-                  h1: ({ children }) => (
-                    <h1 className="text-xl font-bold text-foreground mt-0 mb-3">
-                      {children}
-                    </h1>
-                  ),
-                  h2: ({ children }) => (
-                    <h2 className="text-lg font-semibold text-foreground mt-4 mb-2 first:mt-0">
-                      {children}
-                    </h2>
-                  ),
-                  h3: ({ children }) => (
-                    <h3 className="text-base font-semibold text-foreground mt-3 mb-2 first:mt-0">
-                      {children}
-                    </h3>
-                  ),
-                  p: ({ children }) => (
-                    <p className="text-sm text-foreground/90 mb-3 leading-relaxed break-words">
-                      {children}
-                    </p>
-                  ),
-                  strong: ({ children }) => (
-                    <strong className="font-semibold text-foreground">
-                      {children}
-                    </strong>
-                  ),
-                  ul: ({ children }) => (
-                    <ul className="list-disc list-inside mb-3 space-y-1.5">
-                      {children}
-                    </ul>
-                  ),
-                  ol: ({ children }) => (
-                    <ol className="list-decimal ml-4 mb-3 space-y-2">
-                      {children}
-                    </ol>
-                  ),
-                  li: ({ children }) => (
-                    <li className="text-sm text-foreground/90 leading-relaxed break-words">
-                      {children}
-                    </li>
-                  ),
-                  code: ({ children }) => (
-                    <code className="bg-muted/40 px-1.5 py-0.5 rounded text-xs font-mono text-foreground break-words">
-                      {children}
-                    </code>
-                  ),
-                }}
-              >
-                {analysis}
-              </Markdown>
-            </div>
+            <AnalysisMarkdown>{text}</AnalysisMarkdown>
           </div>
 
-          <div className="flex justify-end">
-            <ActionButton onClick={handleGenerate}>
-              Regenerate Analysis
-              <BrainCircuit className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2" />
-            </ActionButton>
-          </div>
+          {isStreaming ? (
+            <div
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+              role="status"
+              aria-live="polite"
+            >
+              <BrainCircuit className="size-4 animate-pulse" />
+              <span className="animate-pulse">Generating analysis…</span>
+            </div>
+          ) : (
+            <div className="flex justify-end">
+              <ActionButton onClick={handleGenerate}>
+                Regenerate Analysis
+                <BrainCircuit className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2" />
+              </ActionButton>
+            </div>
+          )}
         </CardContent>
       </Card>
     );
@@ -230,7 +288,7 @@ export function AiAnalysisSection({
         {/* Button Row */}
         <div className="flex justify-end">
           <ActionButton onClick={handleGenerate}>
-            Generate AI Analysis
+            {status === "error" ? "Try Again" : "Generate AI Analysis"}
             <BrainCircuit
               className={
                 "size-5 group-hover:translate-x-1 rotate-180 " +

--- a/lib/data/__tests__/aiAnalysisServer.test.ts
+++ b/lib/data/__tests__/aiAnalysisServer.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment node */
+
+jest.mock('@/compositionRoot', () => ({
+  getAiAnalysisDeps: jest.fn(),
+}));
+
+jest.mock('@/usecases/getAiAnalysis', () => ({
+  getAiAnalysis: jest.fn(),
+  getAiAnalysisStream: jest.fn(),
+}));
+
+import { analyzeAsset, analyzeAssetStream } from '../aiAnalysisServer';
+import { getAiAnalysisDeps } from '@/compositionRoot';
+import { getAiAnalysis, getAiAnalysisStream } from '@/usecases/getAiAnalysis';
+
+const mockGetDeps = getAiAnalysisDeps as jest.MockedFunction<typeof getAiAnalysisDeps>;
+const mockGetAnalysis = getAiAnalysis as jest.MockedFunction<typeof getAiAnalysis>;
+const mockGetStream = getAiAnalysisStream as jest.MockedFunction<typeof getAiAnalysisStream>;
+
+const deps = { ai: {} } as never;
+
+describe('aiAnalysisServer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDeps.mockResolvedValue(deps);
+  });
+
+  it('analyzeAsset resolves deps and delegates to the usecase', async () => {
+    mockGetAnalysis.mockResolvedValue('Bullish.');
+    await expect(analyzeAsset('BTC')).resolves.toBe('Bullish.');
+    expect(mockGetDeps).toHaveBeenCalledTimes(1);
+    expect(mockGetAnalysis).toHaveBeenCalledWith(deps, 'BTC');
+  });
+
+  it('analyzeAssetStream resolves deps and yields the usecase chunks', async () => {
+    async function* chunks() {
+      yield 'Bull';
+      yield 'ish.';
+    }
+    mockGetStream.mockReturnValue(chunks());
+
+    const collected: string[] = [];
+    for await (const chunk of analyzeAssetStream('BTC')) {
+      collected.push(chunk);
+    }
+
+    expect(collected).toEqual(['Bull', 'ish.']);
+    expect(mockGetDeps).toHaveBeenCalledTimes(1);
+    expect(mockGetStream).toHaveBeenCalledWith(deps, 'BTC');
+  });
+});

--- a/lib/data/aiAnalysisServer.ts
+++ b/lib/data/aiAnalysisServer.ts
@@ -1,7 +1,19 @@
-import { getAiAnalysis } from '@/usecases/getAiAnalysis';
+import { getAiAnalysis, getAiAnalysisStream } from '@/usecases/getAiAnalysis';
 import { getAiAnalysisDeps } from '@/compositionRoot';
 
 export async function analyzeAsset(symbol: string): Promise<string> {
   const deps = await getAiAnalysisDeps();
   return getAiAnalysis(deps, symbol);
+}
+
+/**
+ * Streaming counterpart to `analyzeAsset`. Resolves the AI deps, then yields
+ * the analysis as incremental string chunks from the usecase. Kept as an async
+ * generator so the dependency resolution happens lazily on first iteration and
+ * any construction error surfaces from the first `next()` (letting the route map
+ * it to an HTTP status before the stream has started).
+ */
+export async function* analyzeAssetStream(symbol: string): AsyncIterable<string> {
+  const deps = await getAiAnalysisDeps();
+  yield* getAiAnalysisStream(deps, symbol);
 }


### PR DESCRIPTION
## Summary

Implements task **NEU-786**: Real end-to-end streaming via the AI SDK (adapter → route → card).

**Type:** feat
**Complexity:** M

The AI SDK streaming adapter (`analyzeAssetStream`), usecase (`getAiAnalysisStream`), and port were already delivered by NEU-785. This wires that stream end-to-end so AI analysis renders token-by-token (shimmer → streaming → reveal). The AI SDK stays contained in the adapter — the route and card consume only plain text, preserving the hexagonal boundary.

## What was done

- **Server data layer:** added `analyzeAssetStream(symbol)` to `lib/data/aiAnalysisServer.ts` (async generator resolving deps then delegating to the streaming usecase); buffered `analyzeAsset` unchanged.
- **Route:** `POST /api/ai-analysis/[symbol]` now returns a `text/plain` `ReadableStream` response. The first chunk is pulled eagerly so pre-stream failures still map to JSON 400/429/502 via `apiErrorResponse`; mid-stream errors call `controller.error`; client disconnect triggers `cancel` → `iterator.return` to stop generation.
- **Card:** `ai-analysis-section.tsx` consumes the byte stream via `response.body.getReader()` with a `idle → loading → streaming → complete / error` state machine, progressive markdown, `AbortController` cleanup on unmount/regenerate, and surfaced error state.
- **Tests:** rewrote the route test for the streaming contract, added card streaming/error tests, and a data-layer test. 15 new cases; patch coverage ≥ 92% lines per changed file.

## Done When

- `POST /api/ai-analysis/[symbol]` responds with `Content-Type: text/plain` and a streamed body (not buffered JSON); pre-stream errors still return the correct JSON status.
- The AI card renders analysis progressively (shimmer → streaming → reveal) and shows the error state on non-ok or mid-stream failure.
- Neither the route nor the card imports `ai`/`@ai-sdk/*`; the buffered `analyzeAsset` path is unchanged.
- `pnpm preflight` exits 0.

## Follow-ups (out of scope)

- `docs/AI-Analysis-Architecture-Review.md` still describes the API as non-streaming and the UI as having no streaming — should be refreshed.
- The untracked `wf-qa.md` documents the old `{ analysis }` JSON success contract for this endpoint.
