### PR TITLE
feat(NEU-801): mock AI-analysis mode for inference-free testing

### DIFF
--- a/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
+++ b/app/api/ai-analysis/[symbol]/__tests__/route.test.ts
@@ -99,6 +99,32 @@ describe('POST /api/ai-analysis/[symbol]', () => {
     expect(returnSpy).toHaveBeenCalled();
   });
 
+  it('forwards a valid x-ai-analysis-mode header as requestedMode', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(iterableOf(['ok']));
+    const req = new Request('http://localhost/api/ai-analysis/BTC', {
+      method: 'POST',
+      headers: { 'x-ai-analysis-mode': 'mock' },
+    });
+    const ctx = { params: Promise.resolve({ symbol: 'BTC' }) };
+
+    await POST(req, ctx);
+
+    expect(mockAnalyzeAssetStream).toHaveBeenCalledWith('BTC', { requestedMode: 'mock' });
+  });
+
+  it('passes requestedMode undefined when the header is absent or invalid', async () => {
+    mockAnalyzeAssetStream.mockReturnValue(iterableOf(['ok']));
+    const req = new Request('http://localhost/api/ai-analysis/BTC', {
+      method: 'POST',
+      headers: { 'x-ai-analysis-mode': 'bogus' },
+    });
+    const ctx = { params: Promise.resolve({ symbol: 'BTC' }) };
+
+    await POST(req, ctx);
+
+    expect(mockAnalyzeAssetStream).toHaveBeenCalledWith('BTC', { requestedMode: undefined });
+  });
+
   it('returns 400 for an invalid symbol without invoking the stream', async () => {
     const [req, ctx] = makeRequest('A'.repeat(21));
     const res = await POST(req, ctx);

--- a/app/api/ai-analysis/[symbol]/route.ts
+++ b/app/api/ai-analysis/[symbol]/route.ts
@@ -3,6 +3,7 @@ import { analyzeAssetStream } from '@/lib/data/aiAnalysisServer';
 import { apiErrorResponse } from '@/lib/http/apiErrorResponse';
 import { logError } from '@/lib/observability';
 import { symbolSchema } from '@/domain/schemas';
+import { AI_ANALYSIS_MODE_HEADER, parseRequestedMode } from '@/lib/aiAnalysisMode';
 
 export async function POST(
   req: Request,
@@ -20,7 +21,11 @@ export async function POST(
       );
     }
 
-    const iterator = analyzeAssetStream(symbol)[Symbol.asyncIterator]();
+    // The client may request a mode via header; the server stays authoritative —
+    // `resolveAiAnalysisMode` only honors it where override is permitted.
+    const requestedMode = parseRequestedMode(req.headers.get(AI_ANALYSIS_MODE_HEADER));
+
+    const iterator = analyzeAssetStream(symbol, { requestedMode })[Symbol.asyncIterator]();
 
     // Pull the first chunk eagerly: a pre-stream failure (missing config, an
     // invalid request, or a first-token upstream error) is wrapped as an

--- a/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
+++ b/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
@@ -9,6 +9,10 @@ jest.mock("react-markdown", () => ({
 }));
 
 import { AiAnalysisSection } from "../ai-analysis-section";
+import {
+  AI_ANALYSIS_MODE_HEADER,
+  AI_ANALYSIS_MODE_STORAGE_KEY,
+} from "@/lib/aiAnalysisMode";
 
 /** Build a fetch Response-like object whose body streams the given chunks. */
 function streamResponse(chunks: string[]): Response {
@@ -44,6 +48,7 @@ describe("AiAnalysisSection", () => {
   afterEach(() => {
     global.fetch = originalFetch;
     jest.clearAllMocks();
+    window.localStorage.clear();
   });
 
   it("renders the empty state with a Generate button", () => {
@@ -77,6 +82,75 @@ describe("AiAnalysisSection", () => {
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/ai-analysis/BTC",
       expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("does not render the inference toggle or send a mode header by default", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(streamResponse(["Bullish."]));
+    global.fetch = fetchMock;
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    expect(
+      screen.queryByRole("group", { name: /inference mode/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+    await screen.findByText(/Bullish\./i);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toEqual({});
+  });
+
+  it("renders the toggle and sends the stored mode header when override is allowed", async () => {
+    window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, "mock");
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(streamResponse(["## Market Bias\n", "Bullish."]));
+    global.fetch = fetchMock;
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
+
+    expect(
+      screen.getByRole("group", { name: /inference mode/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+    await screen.findByText(/Bullish\./i);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/ai-analysis/BTC",
+      expect.objectContaining({
+        method: "POST",
+        headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" },
+      }),
+    );
+  });
+
+  it("persists the selected mode and sends it after toggling", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(streamResponse(["Bullish."]));
+    global.fetch = fetchMock;
+
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
+
+    const mockButton = screen.getByRole("button", { name: /^mock$/i });
+    fireEvent.click(mockButton);
+    expect(mockButton).toHaveAttribute("aria-pressed", "true");
+    expect(window.localStorage.getItem(AI_ANALYSIS_MODE_STORAGE_KEY)).toBe("mock");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /generate ai analysis/i }),
+    );
+    await screen.findByText(/Bullish\./i);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/ai-analysis/BTC",
+      expect.objectContaining({ headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" } }),
     );
   });
 

--- a/app/details/[symbol]/_components/ai-analysis-section.tsx
+++ b/app/details/[symbol]/_components/ai-analysis-section.tsx
@@ -15,13 +15,30 @@ import { useEffect, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ShimmerCard from "@/components/ui/shimmer-card";
 import Markdown from "react-markdown";
+import {
+  AI_ANALYSIS_MODE_HEADER,
+  AI_ANALYSIS_MODE_STORAGE_KEY,
+  type AiAnalysisMode,
+} from "@/lib/aiAnalysisMode";
 
 interface AiAnalysisSectionProps {
   name: string;
   symbol: string;
+  /**
+   * When true, render a per-browser mock/live toggle and send the
+   * `x-ai-analysis-mode` header. Computed server-side from the deployment env;
+   * the server remains authoritative over whether the request is honored.
+   */
+  aiOverrideAllowed?: boolean;
 }
 
 type Status = "idle" | "loading" | "streaming" | "complete" | "error";
+
+function readStoredMode(): AiAnalysisMode | null {
+  if (typeof window === "undefined") return null;
+  const value = window.localStorage.getItem(AI_ANALYSIS_MODE_STORAGE_KEY);
+  return value === "live" || value === "mock" ? value : null;
+}
 
 // Shared markdown renderer overrides — used by both the streaming and the
 // final reveal states so partial and complete analysis render identically.
@@ -73,13 +90,57 @@ function AnalysisMarkdown({ children }: { children: string }) {
   );
 }
 
+/**
+ * QA/demo-only mock vs. live inference toggle, persisted per browser. Rendered
+ * only where the server permits the override (see `aiOverrideAllowed`).
+ */
+function ModeToggle({
+  value,
+  onChange,
+}: {
+  value: AiAnalysisMode | null;
+  onChange: (mode: AiAnalysisMode) => void;
+}) {
+  const modes: AiAnalysisMode[] = ["live", "mock"];
+  return (
+    <div
+      role="group"
+      aria-label="AI inference mode"
+      className="inline-flex items-center gap-1 rounded-full bg-muted/40 p-0.5 text-xs"
+    >
+      <span className="px-1.5 text-muted-foreground">Inference</span>
+      {modes.map((mode) => {
+        const active = value === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(mode)}
+            className={
+              "rounded-full px-2.5 py-0.5 capitalize transition-colors " +
+              (active
+                ? "bg-stone-700/70 text-foreground"
+                : "text-muted-foreground hover:text-foreground")
+            }
+          >
+            {mode}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function AiAnalysisSection({
   name,
   symbol,
+  aiOverrideAllowed = false,
 }: AiAnalysisSectionProps) {
   const [status, setStatus] = useState<Status>("idle");
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [requestedMode, setRequestedMode] = useState<AiAnalysisMode | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const reduce = useReducedMotion();
 
@@ -88,6 +149,19 @@ export function AiAnalysisSection({
   useEffect(() => {
     return () => abortRef.current?.abort();
   }, []);
+
+  // Hydrate the per-browser override preference from localStorage after mount to
+  // avoid an SSR/client mismatch.
+  useEffect(() => {
+    if (aiOverrideAllowed) setRequestedMode(readStoredMode());
+  }, [aiOverrideAllowed]);
+
+  const updateRequestedMode = (mode: AiAnalysisMode) => {
+    setRequestedMode(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, mode);
+    }
+  };
 
   const handleGenerate = async () => {
     // Cancel a previous in-flight request (e.g. a rapid regenerate).
@@ -100,8 +174,14 @@ export function AiAnalysisSection({
     setError(null);
 
     try {
+      const headers: Record<string, string> = {};
+      if (aiOverrideAllowed && requestedMode) {
+        headers[AI_ANALYSIS_MODE_HEADER] = requestedMode;
+      }
+
       const response = await fetch(`/api/ai-analysis/${symbol}`, {
         method: "POST",
+        headers,
         signal: controller.signal,
       });
 
@@ -313,7 +393,12 @@ export function AiAnalysisSection({
         </div>
 
         {/* Button Row */}
-        <div className="flex justify-end">
+        <div className="flex items-center justify-between gap-3">
+          {aiOverrideAllowed ? (
+            <ModeToggle value={requestedMode} onChange={updateRequestedMode} />
+          ) : (
+            <span />
+          )}
           <ActionButton onClick={handleGenerate}>
             {status === "error" ? "Try Again" : "Generate AI Analysis"}
             <BrainCircuit

--- a/app/details/[symbol]/page.tsx
+++ b/app/details/[symbol]/page.tsx
@@ -16,6 +16,8 @@ import ShimmerCard from "@/components/ui/shimmer-card";
 import MarketDataCard from "@/components/crypto/card/market-data-card";
 import TradingActivityCard from "@/components/crypto/card/trading-activity-card";
 import { AiAnalysisSection } from "./_components/ai-analysis-section";
+import { getEnv } from "@/lib/env";
+import { isClientOverrideAllowed } from "@/lib/aiAnalysisMode";
 
 export const dynamic = "force-dynamic";
 
@@ -52,6 +54,10 @@ export default async function SymbolDetailsPage({
     700
   );
   const glowClass = "text-shadow-[0_0_20px_var(--tw-glow-color)]";
+
+  // Computed server-side so the per-browser mock/live toggle only renders where
+  // the server would actually honor the override. The server stays authoritative.
+  const aiOverrideAllowed = isClientOverrideAllowed(getEnv());
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-start px-6 sm:px-12 pb-8 pt-24">
@@ -115,7 +121,11 @@ export default async function SymbolDetailsPage({
         </div>
 
         {/* AI Analysis Section */}
-        <AiAnalysisSection name={asset.name} symbol={asset.symbol} />
+        <AiAnalysisSection
+          name={asset.name}
+          symbol={asset.symbol}
+          aiOverrideAllowed={aiOverrideAllowed}
+        />
       </div>
     </main>
   );

--- a/lib/data/__tests__/aiAnalysisServer.test.ts
+++ b/lib/data/__tests__/aiAnalysisServer.test.ts
@@ -23,6 +23,11 @@ describe('aiAnalysisServer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetDeps.mockResolvedValue(deps);
+    // Mode resolution reads the real env; start from a clean slate each test.
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.VERCEL_ENV;
+    delete process.env.AI_ANALYSIS_MODE;
+    delete process.env.AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE;
   });
 
   it('analyzeAsset resolves deps and delegates to the usecase', async () => {
@@ -47,5 +52,28 @@ describe('aiAnalysisServer', () => {
     expect(collected).toEqual(['Bull', 'ish.']);
     expect(mockGetDeps).toHaveBeenCalledTimes(1);
     expect(mockGetStream).toHaveBeenCalledWith(deps, 'BTC');
+  });
+
+  it('selects mock deps when no API key is set', async () => {
+    mockGetAnalysis.mockResolvedValue('Mock.');
+    await analyzeAsset('BTC');
+    expect(mockGetDeps).toHaveBeenCalledWith('mock');
+  });
+
+  it('forwards a permitted client override into mode resolution', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.VERCEL_ENV = 'preview';
+
+    async function* chunks() {
+      yield 'x';
+    }
+    mockGetStream.mockReturnValue(chunks());
+
+    const collected: string[] = [];
+    for await (const chunk of analyzeAssetStream('BTC', { requestedMode: 'live' })) {
+      collected.push(chunk);
+    }
+
+    expect(mockGetDeps).toHaveBeenCalledWith('live');
   });
 });

--- a/lib/data/aiAnalysisServer.ts
+++ b/lib/data/aiAnalysisServer.ts
@@ -1,19 +1,32 @@
 import { getAiAnalysis, getAiAnalysisStream } from '@/usecases/getAiAnalysis';
 import { getAiAnalysisDeps } from '@/compositionRoot';
+import { getEnv } from '@/lib/env';
+import { resolveAiAnalysisMode, type AiAnalysisMode } from '@/lib/aiAnalysisMode';
 
-export async function analyzeAsset(symbol: string): Promise<string> {
-  const deps = await getAiAnalysisDeps();
+export interface AnalyzeOptions {
+  /** Client-requested mode (e.g. from the gated `x-ai-analysis-mode` header). */
+  requestedMode?: AiAnalysisMode;
+}
+
+export async function analyzeAsset(symbol: string, opts: AnalyzeOptions = {}): Promise<string> {
+  const mode = resolveAiAnalysisMode(getEnv(), opts.requestedMode);
+  const deps = await getAiAnalysisDeps(mode);
   return getAiAnalysis(deps, symbol);
 }
 
 /**
- * Streaming counterpart to `analyzeAsset`. Resolves the AI deps, then yields
+ * Streaming counterpart to `analyzeAsset`. Resolves the effective mode (honoring
+ * a permitted client override), resolves the AI deps for that mode, then yields
  * the analysis as incremental string chunks from the usecase. Kept as an async
  * generator so the dependency resolution happens lazily on first iteration and
  * any construction error surfaces from the first `next()` (letting the route map
  * it to an HTTP status before the stream has started).
  */
-export async function* analyzeAssetStream(symbol: string): AsyncIterable<string> {
-  const deps = await getAiAnalysisDeps();
+export async function* analyzeAssetStream(
+  symbol: string,
+  opts: AnalyzeOptions = {},
+): AsyncIterable<string> {
+  const mode = resolveAiAnalysisMode(getEnv(), opts.requestedMode);
+  const deps = await getAiAnalysisDeps(mode);
   yield* getAiAnalysisStream(deps, symbol);
 }

--- a/src/__tests__/compositionRoot.aiDeps.test.ts
+++ b/src/__tests__/compositionRoot.aiDeps.test.ts
@@ -2,12 +2,16 @@ const mockAnalyzeAsset = jest.fn();
 const mockAnalyzeAssetStream = jest.fn();
 
 const MockOpenAiAnalysisAdapter = jest.fn();
+const MockMockAiAnalysisAdapter = jest.fn();
 
 const MockNewsAdapter = jest.fn().mockImplementation(() => ({ fetchNews: jest.fn() }));
 const MockMockNewsAdapter = jest.fn().mockImplementation(() => ({ fetchNews: jest.fn() }));
 
 jest.mock('@/adapters/openai/OpenAiAnalysisAdapter', () => ({
   OpenAiAnalysisAdapter: MockOpenAiAnalysisAdapter,
+}));
+jest.mock('@/adapters/mock/MockAiAnalysisAdapter', () => ({
+  MockAiAnalysisAdapter: MockMockAiAnalysisAdapter,
 }));
 jest.mock('@/adapters/news/NewsAdapter', () => ({
   NewsAdapter: MockNewsAdapter,
@@ -16,43 +20,64 @@ jest.mock('@/adapters/news/MockNewsAdapter', () => ({
   MockNewsAdapter: MockMockNewsAdapter,
 }));
 
-// Must re-import after mocks are set up and module cache is clean
+// Must re-import after mocks are set up and module cache is clean (also resets
+// the per-mode memoization Map between tests).
 beforeEach(() => {
   jest.resetModules();
-  MockOpenAiAnalysisAdapter.mockReset();
-  MockOpenAiAnalysisAdapter.mockImplementation(() => ({
+  const aiImpl = () => ({
     analyzeAsset: mockAnalyzeAsset,
     analyzeAssetStream: mockAnalyzeAssetStream,
-  }));
+  });
+  MockOpenAiAnalysisAdapter.mockReset();
+  MockOpenAiAnalysisAdapter.mockImplementation(aiImpl);
+  MockMockAiAnalysisAdapter.mockReset();
+  MockMockAiAnalysisAdapter.mockImplementation(aiImpl);
   MockNewsAdapter.mockClear();
   MockMockNewsAdapter.mockClear();
 });
 
 describe('getAiAnalysisDeps', () => {
-  it('returns an object with an ai property implementing AiAnalysisPort', async () => {
+  it('returns an object with an ai property implementing AiAnalysisPort for either mode', async () => {
     const { getAiAnalysisDeps } = await import('../compositionRoot');
-    const deps = await getAiAnalysisDeps();
-
-    expect(deps).toHaveProperty('ai');
-    expect(typeof deps.ai.analyzeAsset).toBe('function');
-    expect(typeof deps.ai.analyzeAssetStream).toBe('function');
+    for (const mode of ['live', 'mock'] as const) {
+      const deps = await getAiAnalysisDeps(mode);
+      expect(deps).toHaveProperty('ai');
+      expect(typeof deps.ai.analyzeAsset).toBe('function');
+      expect(typeof deps.ai.analyzeAssetStream).toBe('function');
+    }
   });
 
-  it('uses MockNewsAdapter when NEWS_API_KEY is not set', async () => {
+  it('builds the OpenAI adapter for live mode', async () => {
+    const { getAiAnalysisDeps } = await import('../compositionRoot');
+    await getAiAnalysisDeps('live');
+
+    expect(MockOpenAiAnalysisAdapter).toHaveBeenCalledTimes(1);
+    expect(MockMockAiAnalysisAdapter).not.toHaveBeenCalled();
+  });
+
+  it('builds the mock adapter for mock mode (no OpenAI adapter, no API key needed)', async () => {
+    const { getAiAnalysisDeps } = await import('../compositionRoot');
+    await getAiAnalysisDeps('mock');
+
+    expect(MockMockAiAnalysisAdapter).toHaveBeenCalledTimes(1);
+    expect(MockOpenAiAnalysisAdapter).not.toHaveBeenCalled();
+  });
+
+  it('uses MockNewsAdapter when NEWS_API_KEY is not set (live)', async () => {
     delete process.env.NEWS_API_KEY;
 
     const { getAiAnalysisDeps } = await import('../compositionRoot');
-    await getAiAnalysisDeps();
+    await getAiAnalysisDeps('live');
 
     expect(MockMockNewsAdapter).toHaveBeenCalled();
     expect(MockNewsAdapter).not.toHaveBeenCalled();
   });
 
-  it('uses NewsAdapter when NEWS_API_KEY is set', async () => {
+  it('uses NewsAdapter when NEWS_API_KEY is set (live)', async () => {
     process.env.NEWS_API_KEY = 'test-key';
 
     const { getAiAnalysisDeps } = await import('../compositionRoot');
-    await getAiAnalysisDeps();
+    await getAiAnalysisDeps('live');
 
     expect(MockNewsAdapter).toHaveBeenCalled();
     expect(MockMockNewsAdapter).not.toHaveBeenCalled();
@@ -60,16 +85,27 @@ describe('getAiAnalysisDeps', () => {
     delete process.env.NEWS_API_KEY;
   });
 
-  it('returns the same instance on concurrent calls (singleton)', async () => {
+  it('returns the same instance on concurrent calls for the same mode (singleton)', async () => {
     const { getAiAnalysisDeps } = await import('../compositionRoot');
 
     const [deps1, deps2] = await Promise.all([
-      getAiAnalysisDeps(),
-      getAiAnalysisDeps(),
+      getAiAnalysisDeps('live'),
+      getAiAnalysisDeps('live'),
     ]);
 
     expect(deps1).toBe(deps2);
     expect(MockOpenAiAnalysisAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches each mode independently', async () => {
+    const { getAiAnalysisDeps } = await import('../compositionRoot');
+
+    const live = await getAiAnalysisDeps('live');
+    const mock = await getAiAnalysisDeps('mock');
+
+    expect(live).not.toBe(mock);
+    expect(MockOpenAiAnalysisAdapter).toHaveBeenCalledTimes(1);
+    expect(MockMockAiAnalysisAdapter).toHaveBeenCalledTimes(1);
   });
 
   it('resets the cache on failure so a later call can retry', async () => {
@@ -80,23 +116,23 @@ describe('getAiAnalysisDeps', () => {
 
     const { getAiAnalysisDeps } = await import('../compositionRoot');
 
-    const p1 = getAiAnalysisDeps();
+    const p1 = getAiAnalysisDeps('live');
     await expect(p1).rejects.toThrow('construction failed');
 
-    // After rejection, cache must be reset so the next call creates a new
-    // promise (rather than re-using the cached rejected one).
-    const p2 = getAiAnalysisDeps();
+    // After rejection, the per-mode cache entry must be cleared so the next call
+    // creates a new promise (rather than re-using the cached rejected one).
+    const p2 = getAiAnalysisDeps('live');
     expect(p2).not.toBe(p1);
     await expect(p2).rejects.toThrow('construction failed');
   });
 
-  it('returns the same instance on sequential calls (singleton)', async () => {
+  it('returns the same instance on sequential calls for the same mode (singleton)', async () => {
     const { getAiAnalysisDeps } = await import('../compositionRoot');
 
-    const deps1 = await getAiAnalysisDeps();
-    const deps2 = await getAiAnalysisDeps();
+    const deps1 = await getAiAnalysisDeps('mock');
+    const deps2 = await getAiAnalysisDeps('mock');
 
     expect(deps1).toBe(deps2);
-    expect(MockOpenAiAnalysisAdapter).toHaveBeenCalledTimes(1);
+    expect(MockMockAiAnalysisAdapter).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/adapters/mock/MockAiAnalysisAdapter.ts
+++ b/src/adapters/mock/MockAiAnalysisAdapter.ts
@@ -1,0 +1,95 @@
+import { AiAnalysisPort } from '@/ports/AiAnalysisPort';
+import { ExternalException } from '@/lib/errors';
+
+/**
+ * Reserved symbols that make the mock simulate a failure, so QA can exercise the
+ * error UI and the regenerate flow without waiting on a real upstream failure.
+ * Both pass `symbolSchema` (length 1–20), so they reach the adapter through the
+ * real route.
+ */
+export const MOCK_PRE_STREAM_ERROR_SYMBOL = '__ERROR_PRE__';
+export const MOCK_MID_STREAM_ERROR_SYMBOL = '__ERROR_MID__';
+
+// Group several "tokens" per yielded chunk and pause briefly between them so the
+// shimmer → streaming → reveal UI is exercised the same way real token streaming
+// drives it.
+const TOKENS_PER_CHUNK = 4;
+const CHUNK_DELAY_MS = 50;
+
+/**
+ * Builds a deterministic, symbol-templated analysis mirroring the real adapter's
+ * sections (Market Bias / Price Analysis / News Sentiment / Key Takeaway).
+ */
+function buildAnalysis(symbol: string): string {
+  const s = symbol.toUpperCase();
+  return [
+    `## AI Analysis for ${s}`,
+    ``,
+    `**Market Bias**: ${s} is showing a mildly bullish short-term bias as momentum stabilizes above recent support.`,
+    ``,
+    `**Price Analysis**: ${s} is trading near its 24h VWAP, with the period high acting as immediate resistance and dip buyers defending the lower range. Volume is steady rather than climactic.`,
+    ``,
+    `**News Sentiment**: Recent ${s} headlines skew constructive — continued ecosystem development and steady inflows outweigh routine profit-taking chatter.`,
+    ``,
+    `**Key Takeaway**: Watch the VWAP reclaim on ${s}; holding above it keeps the short-term bias constructive, while losing the recent range low would neutralize it.`,
+    ``,
+    `_Mock analysis — generated without live inference. Not financial advice._`,
+  ].join('\n');
+}
+
+/** Splits text into streamed chunks on word boundaries, preserving whitespace. */
+function toChunks(text: string): string[] {
+  const tokens = text.match(/\S+\s*/g) ?? [text];
+  const chunks: string[] = [];
+  for (let i = 0; i < tokens.length; i += TOKENS_PER_CHUNK) {
+    chunks.push(tokens.slice(i, i + TOKENS_PER_CHUNK).join(''));
+  }
+  return chunks;
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Inference-free implementation of the AiAnalysisPort. Streams a deterministic,
+ * symbol-templated analysis chunk-by-chunk so the streaming UI runs identically
+ * to live inference, with reserved symbols to simulate pre- and mid-stream
+ * failures.
+ */
+export class MockAiAnalysisAdapter implements AiAnalysisPort {
+  async analyzeAsset(symbol: string): Promise<string> {
+    if (symbol === MOCK_PRE_STREAM_ERROR_SYMBOL || symbol === MOCK_MID_STREAM_ERROR_SYMBOL) {
+      throw new ExternalException(
+        { kind: 'Unavailable', details: { symbol, simulated: true } },
+        `Simulated analysis failure for ${symbol}.`,
+      );
+    }
+    return buildAnalysis(symbol);
+  }
+
+  async *analyzeAssetStream(symbol: string): AsyncIterable<string> {
+    // Pre-stream failure: throw before yielding anything, so the route maps it to
+    // a JSON HTTP error before streaming headers are sent.
+    if (symbol === MOCK_PRE_STREAM_ERROR_SYMBOL) {
+      throw new ExternalException(
+        { kind: 'Unavailable', details: { symbol, simulated: true, phase: 'pre-stream' } },
+        `Simulated pre-stream analysis failure for ${symbol}.`,
+      );
+    }
+
+    const chunks = toChunks(buildAnalysis(symbol));
+
+    for (let i = 0; i < chunks.length; i++) {
+      await delay(CHUNK_DELAY_MS);
+      yield chunks[i];
+
+      // Mid-stream failure: throw after the first chunk so the client reader
+      // rejects rather than receiving a silently truncated analysis.
+      if (symbol === MOCK_MID_STREAM_ERROR_SYMBOL) {
+        throw new ExternalException(
+          { kind: 'Unavailable', details: { symbol, simulated: true, phase: 'mid-stream' } },
+          `Simulated mid-stream analysis failure for ${symbol}.`,
+        );
+      }
+    }
+  }
+}

--- a/src/adapters/mock/__tests__/MockAiAnalysisAdapter.test.ts
+++ b/src/adapters/mock/__tests__/MockAiAnalysisAdapter.test.ts
@@ -1,0 +1,59 @@
+import {
+  MockAiAnalysisAdapter,
+  MOCK_PRE_STREAM_ERROR_SYMBOL,
+  MOCK_MID_STREAM_ERROR_SYMBOL,
+} from '@/adapters/mock/MockAiAnalysisAdapter';
+import { ExternalException } from '@/lib/errors';
+
+async function collect(stream: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const chunk of stream) out.push(chunk);
+  return out;
+}
+
+describe('MockAiAnalysisAdapter', () => {
+  const adapter = new MockAiAnalysisAdapter();
+
+  it('analyzeAsset returns symbol-templated multi-section markdown', async () => {
+    const text = await adapter.analyzeAsset('btc');
+    expect(text).toContain('**Market Bias**');
+    expect(text).toContain('**Price Analysis**');
+    expect(text).toContain('**News Sentiment**');
+    expect(text).toContain('**Key Takeaway**');
+    // Symbol is uppercased and interpolated.
+    expect(text).toContain('BTC');
+    expect(text).not.toContain('btc');
+  });
+
+  it('streams in multiple chunks that reconstruct the full analysis', async () => {
+    const chunks = await collect(adapter.analyzeAssetStream('eth'));
+    expect(chunks.length).toBeGreaterThan(1);
+    const full = chunks.join('');
+    expect(full).toContain('**Key Takeaway**');
+    expect(full).toContain('ETH');
+    expect(full).toBe(await adapter.analyzeAsset('eth'));
+  });
+
+  it('throws before the first chunk for the pre-stream error symbol', async () => {
+    const iterator = adapter
+      .analyzeAssetStream(MOCK_PRE_STREAM_ERROR_SYMBOL)
+      [Symbol.asyncIterator]();
+    await expect(iterator.next()).rejects.toBeInstanceOf(ExternalException);
+  });
+
+  it('yields one chunk then throws for the mid-stream error symbol', async () => {
+    const iterator = adapter
+      .analyzeAssetStream(MOCK_MID_STREAM_ERROR_SYMBOL)
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(typeof first.value).toBe('string');
+    await expect(iterator.next()).rejects.toBeInstanceOf(ExternalException);
+  });
+
+  it('analyzeAsset throws for an error symbol', async () => {
+    await expect(adapter.analyzeAsset(MOCK_PRE_STREAM_ERROR_SYMBOL)).rejects.toBeInstanceOf(
+      ExternalException,
+    );
+  });
+});

--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -5,9 +5,11 @@ import { BinanceAdapter } from '@/adapters/binance/BinanceAdapter';
 import { MockMarketDataAdapter } from '@/adapters/mock/MockMarketDataAdapter';
 import { MockTradingActivityAdapter } from '@/adapters/mock/MockTradingActivityAdapter';
 import { OpenAiAnalysisAdapter } from '@/adapters/openai/OpenAiAnalysisAdapter';
+import { MockAiAnalysisAdapter } from '@/adapters/mock/MockAiAnalysisAdapter';
 import { NewsAdapter } from '@/adapters/news/NewsAdapter';
 import { MockNewsAdapter } from '@/adapters/news/MockNewsAdapter';
 import { getEnv } from '@/lib/env';
+import type { AiAnalysisMode } from '@/lib/aiAnalysisMode';
 
 import type { CoinCapPort } from '@/ports/CoinCapPort';
 import type { AssetWhitelistPort } from '@/ports/AssetWhitelistPort';
@@ -29,28 +31,33 @@ export const pricesDeps = { binance } as const;
 export const marketDataDeps = { marketData } as const;
 export const tradingActivityDeps = { tradingActivity } as const;
 
-// AI analysis deps are memoized so concurrent callers share a single adapter
-// instance (promise-based locking). The promise return type is kept so callers
-// (the route, use case) stay unchanged; construction is now synchronous since
-// the AI SDK imports cleanly under Jest — no dynamic-import workaround needed.
-let _aiAnalysisInit: Promise<{ ai: AiAnalysisPort }> | null = null;
+// AI analysis deps are memoized per mode so concurrent callers share a single
+// adapter instance (promise-based locking). `live` builds the OpenAI adapter
+// (with the news swap); `mock` builds the inference-free stub, which needs no
+// API key. The promise return type is kept so callers stay unchanged.
+const _aiAnalysisInit = new Map<AiAnalysisMode, Promise<{ ai: AiAnalysisPort }>>();
 
-export function getAiAnalysisDeps(): Promise<{ ai: AiAnalysisPort }> {
-  if (!_aiAnalysisInit) {
-    const init = (async () => {
-      const env = getEnv();
-      const news = env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter();
-      return { ai: new OpenAiAnalysisAdapter({ binance, news }) as AiAnalysisPort };
-    })();
-    // Reset the cached promise on failure so a later call can retry. The adapter
-    // is constructed synchronously inside the async IIFE, so a constructor throw
-    // rejects `init` in the same tick; running the reset in this `.catch`
-    // microtask (after the assignment below) keeps it from clobbering the
-    // assignment, and the identity guard avoids discarding a newer in-flight init.
-    init.catch(() => {
-      if (_aiAnalysisInit === init) _aiAnalysisInit = null;
-    });
-    _aiAnalysisInit = init;
-  }
-  return _aiAnalysisInit;
+export function getAiAnalysisDeps(mode: AiAnalysisMode): Promise<{ ai: AiAnalysisPort }> {
+  const cached = _aiAnalysisInit.get(mode);
+  if (cached) return cached;
+
+  const init = (async () => {
+    if (mode === 'mock') {
+      return { ai: new MockAiAnalysisAdapter() as AiAnalysisPort };
+    }
+    const env = getEnv();
+    const news = env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter();
+    return { ai: new OpenAiAnalysisAdapter({ binance, news }) as AiAnalysisPort };
+  })();
+
+  // Reset the cached promise on failure so a later call can retry. The adapter
+  // is constructed synchronously inside the async IIFE, so a constructor throw
+  // rejects `init` in the same tick; running the reset in this `.catch`
+  // microtask (after the set below) keeps it from clobbering the assignment, and
+  // the identity guard avoids discarding a newer in-flight init for this mode.
+  init.catch(() => {
+    if (_aiAnalysisInit.get(mode) === init) _aiAnalysisInit.delete(mode);
+  });
+  _aiAnalysisInit.set(mode, init);
+  return init;
 }

--- a/src/lib/__tests__/aiAnalysisMode.test.ts
+++ b/src/lib/__tests__/aiAnalysisMode.test.ts
@@ -21,10 +21,17 @@ describe('parseRequestedMode', () => {
 });
 
 describe('isClientOverrideAllowed', () => {
-  it('allows in any non-production environment', () => {
+  it('allows in a positively non-production environment', () => {
     expect(isClientOverrideAllowed({ VERCEL_ENV: 'preview' })).toBe(true);
     expect(isClientOverrideAllowed({ VERCEL_ENV: 'development' })).toBe(true);
-    expect(isClientOverrideAllowed({})).toBe(true);
+    expect(isClientOverrideAllowed({ NODE_ENV: 'development' })).toBe(true);
+  });
+
+  it('denies when the environment is indeterminate or non-Vercel production', () => {
+    // Neither var set → cannot prove non-production → deny.
+    expect(isClientOverrideAllowed({})).toBe(false);
+    // Non-Vercel prod (VERCEL_ENV unset, NODE_ENV=production) → deny.
+    expect(isClientOverrideAllowed({ NODE_ENV: 'production' })).toBe(false);
   });
 
   it('disallows when an explicit AI_ANALYSIS_MODE kill-switch is set', () => {
@@ -81,7 +88,17 @@ describe('resolveAiAnalysisMode', () => {
   it('defaults by environment: production with key is live, others mock', () => {
     expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'production' })).toBe('live');
     expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'preview' })).toBe('mock');
+    // Indeterminate (no signals) defaults to mock — never silently bills.
     expect(resolveAiAnalysisMode({ ...withKey })).toBe('mock');
+  });
+
+  it('falls back to NODE_ENV when VERCEL_ENV is unset (non-Vercel runtimes)', () => {
+    expect(resolveAiAnalysisMode({ ...withKey, NODE_ENV: 'production' })).toBe('live');
+    expect(resolveAiAnalysisMode({ ...withKey, NODE_ENV: 'development' })).toBe('mock');
+    // VERCEL_ENV is authoritative when present — NODE_ENV must not override it.
+    expect(
+      resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'preview', NODE_ENV: 'production' }),
+    ).toBe('mock');
   });
 
   it('honors a permitted client override', () => {

--- a/src/lib/__tests__/aiAnalysisMode.test.ts
+++ b/src/lib/__tests__/aiAnalysisMode.test.ts
@@ -1,0 +1,105 @@
+import {
+  resolveAiAnalysisMode,
+  isClientOverrideAllowed,
+  parseRequestedMode,
+  type AiAnalysisEnv,
+} from '@/lib/aiAnalysisMode';
+
+describe('parseRequestedMode', () => {
+  it('accepts the two valid modes', () => {
+    expect(parseRequestedMode('live')).toBe('live');
+    expect(parseRequestedMode('mock')).toBe('mock');
+  });
+
+  it('rejects anything else', () => {
+    expect(parseRequestedMode('LIVE')).toBeUndefined();
+    expect(parseRequestedMode('real')).toBeUndefined();
+    expect(parseRequestedMode('')).toBeUndefined();
+    expect(parseRequestedMode(null)).toBeUndefined();
+    expect(parseRequestedMode(undefined)).toBeUndefined();
+  });
+});
+
+describe('isClientOverrideAllowed', () => {
+  it('allows in any non-production environment', () => {
+    expect(isClientOverrideAllowed({ VERCEL_ENV: 'preview' })).toBe(true);
+    expect(isClientOverrideAllowed({ VERCEL_ENV: 'development' })).toBe(true);
+    expect(isClientOverrideAllowed({})).toBe(true);
+  });
+
+  it('disallows when an explicit AI_ANALYSIS_MODE kill-switch is set', () => {
+    expect(isClientOverrideAllowed({ AI_ANALYSIS_MODE: 'mock', VERCEL_ENV: 'preview' })).toBe(false);
+    expect(
+      isClientOverrideAllowed({
+        AI_ANALYSIS_MODE: 'live',
+        AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: 'true',
+      }),
+    ).toBe(false);
+  });
+
+  it('disallows in production unless explicitly enabled', () => {
+    expect(isClientOverrideAllowed({ VERCEL_ENV: 'production' })).toBe(false);
+    expect(
+      isClientOverrideAllowed({ VERCEL_ENV: 'production', AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: 'true' }),
+    ).toBe(true);
+    expect(
+      isClientOverrideAllowed({ VERCEL_ENV: 'production', AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: '1' }),
+    ).toBe(true);
+    expect(
+      isClientOverrideAllowed({ VERCEL_ENV: 'production', AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: 'false' }),
+    ).toBe(false);
+  });
+});
+
+describe('resolveAiAnalysisMode', () => {
+  const withKey: AiAnalysisEnv = { OPENAI_API_KEY: 'sk-test' };
+
+  it('lets an explicit AI_ANALYSIS_MODE win over the env default', () => {
+    expect(
+      resolveAiAnalysisMode({ ...withKey, AI_ANALYSIS_MODE: 'mock', VERCEL_ENV: 'production' }),
+    ).toBe('mock');
+    expect(
+      resolveAiAnalysisMode({ ...withKey, AI_ANALYSIS_MODE: 'live', VERCEL_ENV: 'preview' }),
+    ).toBe('live');
+  });
+
+  it('degrades an explicit live with no key to mock', () => {
+    expect(resolveAiAnalysisMode({ AI_ANALYSIS_MODE: 'live' })).toBe('mock');
+  });
+
+  it('treats an explicit mode as a kill-switch that beats a client override', () => {
+    expect(
+      resolveAiAnalysisMode({ ...withKey, AI_ANALYSIS_MODE: 'mock', VERCEL_ENV: 'preview' }, 'live'),
+    ).toBe('mock');
+  });
+
+  it('falls back to mock when no API key is present, regardless of environment', () => {
+    expect(resolveAiAnalysisMode({ VERCEL_ENV: 'production' })).toBe('mock');
+    expect(resolveAiAnalysisMode({ VERCEL_ENV: 'preview' })).toBe('mock');
+  });
+
+  it('defaults by environment: production with key is live, others mock', () => {
+    expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'production' })).toBe('live');
+    expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'preview' })).toBe('mock');
+    expect(resolveAiAnalysisMode({ ...withKey })).toBe('mock');
+  });
+
+  it('honors a permitted client override', () => {
+    expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'preview' }, 'live')).toBe('live');
+    expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'development' }, 'mock')).toBe('mock');
+  });
+
+  it('ignores a client override in production unless explicitly enabled', () => {
+    expect(resolveAiAnalysisMode({ ...withKey, VERCEL_ENV: 'production' }, 'mock')).toBe('live');
+    expect(
+      resolveAiAnalysisMode(
+        { ...withKey, VERCEL_ENV: 'production', AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: 'true' },
+        'mock',
+      ),
+    ).toBe('mock');
+  });
+
+  it('degrades a requested live with no key to mock', () => {
+    expect(resolveAiAnalysisMode({ VERCEL_ENV: 'preview' }, 'live')).toBe('mock');
+  });
+});

--- a/src/lib/aiAnalysisMode.ts
+++ b/src/lib/aiAnalysisMode.ts
@@ -22,6 +22,29 @@ export interface AiAnalysisEnv {
   AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE?: string;
   OPENAI_API_KEY?: string;
   VERCEL_ENV?: 'production' | 'preview' | 'development';
+  NODE_ENV?: 'development' | 'production' | 'test';
+}
+
+/**
+ * Positively production? On Vercel, `VERCEL_ENV` is authoritative (and is the
+ * only thing that can tell preview from production — never use `NODE_ENV` for
+ * that, since preview builds also run with `NODE_ENV=production`). Off Vercel
+ * (`VERCEL_ENV` unset, e.g. a self-hosted `next start`), fall back to `NODE_ENV`
+ * so a non-Vercel production runtime is still locked down.
+ */
+function isProduction(env: AiAnalysisEnv): boolean {
+  if (env.VERCEL_ENV) return env.VERCEL_ENV === 'production';
+  return env.NODE_ENV === 'production';
+}
+
+/**
+ * Positively non-production? Requires a definite signal — an unknown
+ * environment is NOT treated as non-production, so a prod-like deployment that
+ * sets neither var never accidentally enables overrides.
+ */
+function isNonProduction(env: AiAnalysisEnv): boolean {
+  if (env.VERCEL_ENV) return env.VERCEL_ENV !== 'production';
+  return env.NODE_ENV === 'development' || env.NODE_ENV === 'test';
 }
 
 /** Narrows an arbitrary header/string value to a valid mode, or `undefined`. */
@@ -39,13 +62,14 @@ function isTruthyFlag(value: string | undefined): boolean {
  * Whether a per-browser override is permitted for this deployment. An explicit
  * `AI_ANALYSIS_MODE` kill-switch is absolute and disables overrides entirely
  * (so the UI toggle is only shown where it would actually take effect).
- * Otherwise allowed in any non-production environment, or in production only
- * when explicitly enabled via `AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE`.
+ * Otherwise allowed only in a positively non-production environment, or in
+ * production only when explicitly enabled via `AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE`.
+ * An indeterminate environment is treated as production (override denied).
  */
 export function isClientOverrideAllowed(env: AiAnalysisEnv): boolean {
   if (env.AI_ANALYSIS_MODE) return false;
   if (isTruthyFlag(env.AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE)) return true;
-  return env.VERCEL_ENV !== 'production';
+  return isNonProduction(env);
 }
 
 /**
@@ -57,7 +81,7 @@ export function isClientOverrideAllowed(env: AiAnalysisEnv): boolean {
  * 2. A client-requested mode, but only when override is permitted. A requested
  *    `live` with no key degrades to `mock`.
  * 3. No `OPENAI_API_KEY` ⇒ `mock` (graceful, mirrors the news adapter swap).
- * 4. Environment default: `VERCEL_ENV === 'production'` ⇒ `live`, else `mock`.
+ * 4. Environment default: positively production ⇒ `live`, else `mock`.
  */
 export function resolveAiAnalysisMode(
   env: AiAnalysisEnv,
@@ -75,5 +99,5 @@ export function resolveAiAnalysisMode(
 
   if (!hasKey) return 'mock';
 
-  return env.VERCEL_ENV === 'production' ? 'live' : 'mock';
+  return isProduction(env) ? 'live' : 'mock';
 }

--- a/src/lib/aiAnalysisMode.ts
+++ b/src/lib/aiAnalysisMode.ts
@@ -1,0 +1,79 @@
+/**
+ * AI-analysis mode policy.
+ *
+ * The streaming AI-analysis feature can run against the real LLM (`live`) or a
+ * deterministic, inference-free stub (`mock`). This module is the single source
+ * of truth for which mode a request resolves to. It is intentionally free of
+ * server-only imports so it can be shared by the client component that sends the
+ * override header.
+ */
+
+export type AiAnalysisMode = 'live' | 'mock';
+
+/** Request header a gated client uses to request a specific mode. */
+export const AI_ANALYSIS_MODE_HEADER = 'x-ai-analysis-mode';
+
+/** localStorage key the per-browser override toggle persists its preference to. */
+export const AI_ANALYSIS_MODE_STORAGE_KEY = 'ai-analysis-mode';
+
+/** The subset of environment values the mode policy depends on. */
+export interface AiAnalysisEnv {
+  AI_ANALYSIS_MODE?: AiAnalysisMode;
+  AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE?: string;
+  OPENAI_API_KEY?: string;
+  VERCEL_ENV?: 'production' | 'preview' | 'development';
+}
+
+/** Narrows an arbitrary header/string value to a valid mode, or `undefined`. */
+export function parseRequestedMode(raw: string | null | undefined): AiAnalysisMode | undefined {
+  return raw === 'live' || raw === 'mock' ? raw : undefined;
+}
+
+function isTruthyFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+/**
+ * Whether a per-browser override is permitted for this deployment. An explicit
+ * `AI_ANALYSIS_MODE` kill-switch is absolute and disables overrides entirely
+ * (so the UI toggle is only shown where it would actually take effect).
+ * Otherwise allowed in any non-production environment, or in production only
+ * when explicitly enabled via `AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE`.
+ */
+export function isClientOverrideAllowed(env: AiAnalysisEnv): boolean {
+  if (env.AI_ANALYSIS_MODE) return false;
+  if (isTruthyFlag(env.AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE)) return true;
+  return env.VERCEL_ENV !== 'production';
+}
+
+/**
+ * Resolve the effective analysis mode. Precedence:
+ *
+ * 1. Explicit `AI_ANALYSIS_MODE` wins (the central kill-switch — it beats any
+ *    client override). A forced `live` with no API key degrades to `mock`
+ *    rather than erroring.
+ * 2. A client-requested mode, but only when override is permitted. A requested
+ *    `live` with no key degrades to `mock`.
+ * 3. No `OPENAI_API_KEY` ⇒ `mock` (graceful, mirrors the news adapter swap).
+ * 4. Environment default: `VERCEL_ENV === 'production'` ⇒ `live`, else `mock`.
+ */
+export function resolveAiAnalysisMode(
+  env: AiAnalysisEnv,
+  requested?: AiAnalysisMode,
+): AiAnalysisMode {
+  const hasKey = Boolean(env.OPENAI_API_KEY);
+
+  if (env.AI_ANALYSIS_MODE) {
+    return env.AI_ANALYSIS_MODE === 'live' && !hasKey ? 'mock' : env.AI_ANALYSIS_MODE;
+  }
+
+  if (requested && isClientOverrideAllowed(env)) {
+    return requested === 'live' && !hasKey ? 'mock' : requested;
+  }
+
+  if (!hasKey) return 'mock';
+
+  return env.VERCEL_ENV === 'production' ? 'live' : 'mock';
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 const EnvSchema = z.object({
   // example: "NEXT_PUBLIC_API_URL": z.string().url().optional(),
   NODE_ENV: z.enum(['development', 'production', 'test']).optional(),
+  // Vercel sets VERCEL_ENV to distinguish production from preview/development.
+  // Unlike NODE_ENV (which is "production" for preview builds too), this is the
+  // correct discriminator for the AI-analysis mode default.
+  VERCEL_ENV: z.enum(['production', 'preview', 'development']).optional(),
   COINCAP_API_KEY: z.string().optional(),
   COINCAP_BASE_URL: z.string().url().optional(),
   BINANCE_API_KEY: z.string().optional(),
@@ -11,6 +15,12 @@ const EnvSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_MODEL: z.string().optional(),
   NEWS_API_KEY: z.string().optional(),
+  // AI-analysis mode kill-switch: forces the live or mock analysis adapter
+  // regardless of environment. Unset → resolved from VERCEL_ENV / key presence.
+  AI_ANALYSIS_MODE: z.enum(['live', 'mock']).optional(),
+  // When truthy, permits the gated per-browser `x-ai-analysis-mode` override
+  // even in production. In non-prod the override is allowed regardless.
+  AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: z.string().optional(),
 });
 
 type Env = z.infer<typeof EnvSchema>;


### PR DESCRIPTION
## Summary

Implements **NEU-801**: a mock AI-analysis mode so the streaming AI-analysis feature (NEU-785/786/797) can be exercised end-to-end without real LLM inference.

**Type:** feat · **Complexity:** M

## What was done

- New `MockAiAnalysisAdapter` (`AiAnalysisPort`) streams deterministic, symbol-templated multi-section markdown (Market Bias / Price Analysis / News Sentiment / Key Takeaway) chunk-by-chunk, so the CTA → shimmer → stream → reveal UI runs identically to live inference. Reserved symbols `__ERROR_PRE__` / `__ERROR_MID__` simulate pre- and mid-stream failures for QA.
- New `src/lib/aiAnalysisMode.ts` centralizes mode policy. Resolution precedence: explicit `AI_ANALYSIS_MODE` (kill-switch) → no `OPENAI_API_KEY` ⇒ mock → `VERCEL_ENV` default (prod ⇒ live, else mock). Non-prod and key-less deployments get the mock by default with no token spend.
- `getAiAnalysisDeps(mode)` memoizes per mode (live → OpenAI adapter, mock → stub), preserving the retry-on-failure reset.
- Gated per-browser override: a `localStorage` toggle sends `x-ai-analysis-mode`; the server is authoritative and only honors it where override is permitted (non-prod or `AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE`), so a prod visitor can never force live inference.
- Added `AI_ANALYSIS_MODE`, `AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE`, and `VERCEL_ENV` to the env schema. The route response contract is unchanged.

## Done When

- `pnpm preflight` exits 0 (typecheck + eslint + jest: 32 suites, 250 passed).
- With `OPENAI_API_KEY` unset and no `AI_ANALYSIS_MODE`, resolution yields the mock adapter and streams symbol-templated multi-section markdown — no OpenAI call.
- New unit tests for `aiAnalysisMode`, `MockAiAnalysisAdapter`, and per-mode `getAiAnalysisDeps` pass.
