### PR TITLE
feat(NEU-22): Create AI Analysis Card Container Component

### DIFF
--- a/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
+++ b/app/details/[symbol]/_components/__tests__/ai-analysis-section.test.tsx
@@ -1,12 +1,60 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-// react-markdown ships as ESM and is not transformed by Jest; mock it with a
-// passthrough that renders the raw markdown text so we can assert on content.
+// react-markdown ships as ESM and is not transformed the same way; mock it with
+// a passthrough that renders the raw markdown text so we can assert on content.
 jest.mock("react-markdown", () => ({
   __esModule: true,
   default: ({ children }: { children: string }) => <>{children}</>,
 }));
+
+// Controllable mock of the AI SDK `useCompletion` hook. The component derives
+// all of its render state from the hook return values, so the tests drive those
+// values directly and assert on the resulting UI + the arguments the component
+// passes back into `complete()`. jest only allows the factory to reference
+// out-of-scope identifiers prefixed with `mock`.
+type MockHookState = {
+  completion: string;
+  isLoading: boolean;
+  error: Error | undefined;
+};
+const mockHookState: MockHookState = {
+  completion: "",
+  isLoading: false,
+  error: undefined,
+};
+let mockComplete: jest.Mock;
+let mockStop: jest.Mock;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCapturedOptions: any;
+let mockOnFinish: (() => void) | undefined;
+let mockForce: (() => void) | undefined;
+
+jest.mock("@ai-sdk/react", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useCompletion: (options: any) => {
+      mockCapturedOptions = options;
+      mockOnFinish = options?.onFinish;
+      const [, force] = React.useReducer((c: number) => c + 1, 0);
+      mockForce = force;
+      return {
+        completion: mockHookState.completion,
+        isLoading: mockHookState.isLoading,
+        error: mockHookState.error,
+        complete: mockComplete,
+        stop: mockStop,
+        setCompletion: jest.fn(),
+        input: "",
+        setInput: jest.fn(),
+        handleInputChange: jest.fn(),
+        handleSubmit: jest.fn(),
+      };
+    },
+  };
+});
 
 import { AiAnalysisSection } from "../ai-analysis-section";
 import {
@@ -14,84 +62,56 @@ import {
   AI_ANALYSIS_MODE_STORAGE_KEY,
 } from "@/lib/aiAnalysisMode";
 
-/** Build a fetch Response-like object whose body streams the given chunks. */
-function streamResponse(chunks: string[]): Response {
-  const encoder = new TextEncoder();
-  return {
-    ok: true,
-    body: new ReadableStream<Uint8Array>({
-      start(controller) {
-        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
-        controller.close();
-      },
-    }),
-  } as unknown as Response;
-}
-
-/** A streaming Response that emits one chunk then errors the stream. */
-function midStreamErrorResponse(first: string): Response {
-  const encoder = new TextEncoder();
-  return {
-    ok: true,
-    body: new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoder.encode(first));
-        controller.error(new Error("stream blew up"));
-      },
-    }),
-  } as unknown as Response;
+/** Mutate the mocked hook state (and optionally fire onFinish), then re-render. */
+function setHook(
+  partial: Partial<MockHookState>,
+  opts: { finish?: boolean } = {},
+) {
+  act(() => {
+    Object.assign(mockHookState, partial);
+    if (opts.finish) mockOnFinish?.();
+    mockForce?.();
+  });
 }
 
 describe("AiAnalysisSection", () => {
-  const originalFetch = global.fetch;
+  beforeEach(() => {
+    mockHookState.completion = "";
+    mockHookState.isLoading = false;
+    mockHookState.error = undefined;
+    mockComplete = jest.fn();
+    mockStop = jest.fn();
+    mockCapturedOptions = undefined;
+    mockOnFinish = undefined;
+    mockForce = undefined;
+  });
 
   afterEach(() => {
-    global.fetch = originalFetch;
     jest.clearAllMocks();
     window.localStorage.clear();
   });
 
-  it("renders the empty state with a Generate button", () => {
+  it("points the hook at the per-symbol route using the text stream protocol", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    expect(mockCapturedOptions.api).toBe("/api/ai-analysis/BTC");
+    expect(mockCapturedOptions.streamProtocol).toBe("text");
+  });
+
+  it("renders the idle empty state with a Generate button", () => {
     render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
 
-    expect(screen.getByText("AI Analysis")).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /ai analysis/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no analysis generated yet/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /generate ai analysis/i }),
     ).toBeInTheDocument();
   });
 
-  it("streams the analysis and then reveals it with a Regenerate button", async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue(
-        // Leading empty chunk exercises the "skip empty chunk" path.
-        streamResponse(["", "## Market Bias\n", "Bullish ", "momentum building."]),
-      );
-
+  it("triggers a generation with an empty prompt and no mode header by default", () => {
     render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /generate ai analysis/i }),
-    );
 
-    // Progressive content is rendered from the stream.
-    expect(await screen.findByText(/Bullish momentum building\./i)).toBeInTheDocument();
-    // On completion the Regenerate CTA appears.
-    expect(
-      await screen.findByRole("button", { name: /regenerate analysis/i }),
-    ).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith(
-      "/api/ai-analysis/BTC",
-      expect.objectContaining({ method: "POST" }),
-    );
-  });
-
-  it("does not render the inference toggle or send a mode header by default", async () => {
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValue(streamResponse(["Bullish."]));
-    global.fetch = fetchMock;
-
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
     expect(
       screen.queryByRole("group", { name: /inference mode/i }),
     ).not.toBeInTheDocument();
@@ -99,19 +119,128 @@ describe("AiAnalysisSection", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /generate ai analysis/i }),
     );
-    await screen.findByText(/Bullish\./i);
 
-    const [, init] = fetchMock.mock.calls[0];
-    expect(init.headers).toEqual({});
+    expect(mockComplete).toHaveBeenCalledWith("", undefined);
   });
 
-  it("renders the toggle and sends the stored mode header when override is allowed", async () => {
-    window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, "mock");
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValue(streamResponse(["## Market Bias\n", "Bullish."]));
-    global.fetch = fetchMock;
+  it("shows the shimmer loading state with a polite status while awaiting the first token", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({ isLoading: true, completion: "" });
 
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/generating analysis/i);
+    // The empty/idle CTA is gone while loading.
+    expect(
+      screen.queryByRole("button", { name: /generate ai analysis/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders streaming markdown progressively inside a labelled region", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({ isLoading: true, completion: "## Market Bias\nBullish momentum" });
+
+    expect(
+      screen.getByRole("region", { name: /ai analysis/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Bullish momentum/)).toBeInTheDocument();
+    // A live status region exists during streaming.
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    // No Regenerate button yet — still streaming.
+    expect(
+      screen.queryByRole("button", { name: /regenerate analysis/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reveals the complete analysis with a Regenerate button and an announcement", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({ isLoading: true, completion: "Bullish momentum building." });
+    setHook(
+      { isLoading: false, completion: "Bullish momentum building." },
+      { finish: true },
+    );
+
+    expect(screen.getByText("Bullish momentum building.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /regenerate analysis/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/analysis ready/i);
+  });
+
+  it("regenerates: clicking Regenerate triggers another generation", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({ isLoading: false, completion: "Some analysis." }, { finish: true });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /regenerate analysis/i }),
+    );
+
+    expect(mockComplete).toHaveBeenCalledWith("", undefined);
+  });
+
+  it("treats a finished-but-empty stream as complete, not idle", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    // A successful stream that emitted no text still resolves to the complete
+    // card (Regenerate available) rather than silently reverting to idle.
+    setHook({ isLoading: true, completion: "" });
+    setHook({ isLoading: false, completion: "" }, { finish: true });
+
+    expect(
+      screen.getByRole("button", { name: /regenerate analysis/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /generate ai analysis/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("normalizes a JSON error body and surfaces it as an alert with Try Again", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    // The AI SDK text protocol surfaces the route's JSON `{ error }` body
+    // verbatim in `error.message`; the component recovers the message.
+    setHook({
+      isLoading: false,
+      error: new Error(JSON.stringify({ error: "Too many requests" })),
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Too many requests");
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the raw message for a non-JSON (mid-stream) error", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({
+      isLoading: false,
+      completion: "Partial analysis ",
+      error: new Error("stream blew up"),
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("stream blew up");
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a generic message for an error with no message text", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({ isLoading: false, error: new Error("") });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
+  });
+
+  it("falls back to the raw text for a JSON error body without an error field", () => {
+    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    setHook({
+      isLoading: false,
+      error: new Error(JSON.stringify({ message: "nope" })),
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent('{"message":"nope"}');
+  });
+
+  it("renders the toggle and sends the stored mode header when override is allowed", () => {
+    window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, "mock");
     render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
 
     expect(
@@ -121,68 +250,39 @@ describe("AiAnalysisSection", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /generate ai analysis/i }),
     );
-    await screen.findByText(/Bullish\./i);
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/ai-analysis/BTC",
-      expect.objectContaining({
-        method: "POST",
-        headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" },
-      }),
-    );
+    expect(mockComplete).toHaveBeenCalledWith("", {
+      headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" },
+    });
   });
 
-  it("persists the selected mode and sends it after toggling", async () => {
-    const fetchMock = jest.fn().mockResolvedValue(streamResponse(["Bullish."]));
-    global.fetch = fetchMock;
-
+  it("persists the selected mode and sends it after toggling", () => {
     render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
 
     const mockButton = screen.getByRole("button", { name: /^mock$/i });
     fireEvent.click(mockButton);
     expect(mockButton).toHaveAttribute("aria-pressed", "true");
-    expect(window.localStorage.getItem(AI_ANALYSIS_MODE_STORAGE_KEY)).toBe("mock");
+    expect(window.localStorage.getItem(AI_ANALYSIS_MODE_STORAGE_KEY)).toBe(
+      "mock",
+    );
 
     fireEvent.click(
       screen.getByRole("button", { name: /generate ai analysis/i }),
     );
-    await screen.findByText(/Bullish\./i);
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/ai-analysis/BTC",
-      expect.objectContaining({ headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" } }),
-    );
+    expect(mockComplete).toHaveBeenCalledWith("", {
+      headers: { [AI_ANALYSIS_MODE_HEADER]: "mock" },
+    });
   });
 
-  it("shows the error state when the response is not ok", async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      json: async () => ({ error: "Too many requests" }),
-    } as unknown as Response);
-
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /generate ai analysis/i }),
+  it("aborts the in-flight stream on unmount", () => {
+    const { unmount } = render(
+      <AiAnalysisSection name="Bitcoin" symbol="BTC" />,
     );
+    setHook({ isLoading: true, completion: "partial" });
 
-    expect(await screen.findByText("Too many requests")).toBeInTheDocument();
-    expect(
-      await screen.findByRole("button", { name: /try again/i }),
-    ).toBeInTheDocument();
-  });
+    unmount();
 
-  it("shows the error state when the stream fails mid-way", async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue(midStreamErrorResponse("Partial analysis "));
-
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /generate ai analysis/i }),
-    );
-
-    expect(
-      await screen.findByRole("button", { name: /try again/i }),
-    ).toBeInTheDocument();
+    expect(mockStop).toHaveBeenCalled();
   });
 });

--- a/app/details/[symbol]/_components/ai-analysis-section.tsx
+++ b/app/details/[symbol]/_components/ai-analysis-section.tsx
@@ -11,10 +11,11 @@ import {
 import { ActionButton } from "@/components/ui/action-button";
 import { BrainCircuit } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import type { Components } from "react-markdown";
 import ShimmerCard from "@/components/ui/shimmer-card";
 import Markdown from "react-markdown";
+import { useCompletion } from "@ai-sdk/react";
 import {
   AI_ANALYSIS_MODE_HEADER,
   AI_ANALYSIS_MODE_STORAGE_KEY,
@@ -38,6 +39,57 @@ function readStoredMode(): AiAnalysisMode | null {
   if (typeof window === "undefined") return null;
   const value = window.localStorage.getItem(AI_ANALYSIS_MODE_STORAGE_KEY);
   return value === "live" || value === "mock" ? value : null;
+}
+
+// The per-browser mode preference is read through `useSyncExternalStore` so the
+// value is SSR-safe (the server snapshot is null, avoiding a hydration mismatch)
+// and updates reactively — both from this tab's writes and cross-tab `storage`
+// events — without a setState-in-effect hydration hack.
+const modeListeners = new Set<() => void>();
+
+function subscribeStoredMode(callback: () => void) {
+  modeListeners.add(callback);
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", callback);
+  }
+  return () => {
+    modeListeners.delete(callback);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("storage", callback);
+    }
+  };
+}
+
+function getServerStoredMode(): AiAnalysisMode | null {
+  return null;
+}
+
+function writeStoredMode(mode: AiAnalysisMode) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, mode);
+  }
+  // Notify same-tab subscribers — the `storage` event only fires cross-tab.
+  modeListeners.forEach((listener) => listener());
+}
+
+/**
+ * The route returns a JSON `{ error }` body on a pre-stream failure, which the
+ * AI SDK's text stream protocol surfaces verbatim as `error.message`. Recover
+ * the clean message where possible, falling back to the raw text.
+ */
+function normalizeError(error: Error | undefined): string | null {
+  if (!error) return null;
+  const raw = error.message?.trim();
+  if (!raw) return "Something went wrong";
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.error === "string" && parsed.error.trim()) {
+      return parsed.error;
+    }
+  } catch {
+    // Not JSON (e.g. a mid-stream failure) — fall through to the raw message.
+  }
+  return raw;
 }
 
 // Shared markdown renderer overrides — used by both the streaming and the
@@ -137,109 +189,94 @@ export function AiAnalysisSection({
   symbol,
   aiOverrideAllowed = false,
 }: AiAnalysisSectionProps) {
-  const [status, setStatus] = useState<Status>("idle");
-  const [text, setText] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [requestedMode, setRequestedMode] = useState<AiAnalysisMode | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  const requestedMode = useSyncExternalStore(
+    subscribeStoredMode,
+    readStoredMode,
+    getServerStoredMode,
+  );
+  // Whether a generation has finished successfully at least once. Distinguishes
+  // the pristine "idle" state from a finished run that happened to stream no
+  // text, so an empty-but-successful response still reveals the completed card
+  // (matching the pre-migration behavior) instead of silently reverting to idle.
+  const [hasCompleted, setHasCompleted] = useState(false);
   const reduce = useReducedMotion();
+  const titleId = useId();
+
+  // The AI SDK hook owns the streaming lifecycle: `completion` accumulates the
+  // streamed text, `isLoading` covers the request window, `error` captures
+  // failures, and `stop` aborts the in-flight request. Render state is derived
+  // from these rather than tracked with ad-hoc flags. The route streams plain
+  // token chunks, so the `text` stream protocol consumes it directly.
+  const { completion, complete, error, isLoading, stop } = useCompletion({
+    api: `/api/ai-analysis/${symbol}`,
+    streamProtocol: "text",
+    onFinish: () => setHasCompleted(true),
+  });
 
   // Abort any in-flight stream when the component unmounts (e.g. the user
-  // navigates away mid-stream) so the server stops generating.
+  // navigates away mid-stream) so the server stops generating. `stop` can change
+  // identity between renders, so call the latest via a ref to keep the cleanup
+  // strictly unmount-only.
+  const stopRef = useRef(stop);
   useEffect(() => {
-    return () => abortRef.current?.abort();
-  }, []);
+    stopRef.current = stop;
+  });
+  useEffect(() => () => stopRef.current(), []);
 
-  // Hydrate the per-browser override preference from localStorage after mount to
-  // avoid an SSR/client mismatch.
-  useEffect(() => {
-    if (aiOverrideAllowed) setRequestedMode(readStoredMode());
-  }, [aiOverrideAllowed]);
-
-  const updateRequestedMode = (mode: AiAnalysisMode) => {
-    setRequestedMode(mode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, mode);
-    }
+  const handleGenerate = () => {
+    // Send the per-browser override as a request header where permitted. Passing
+    // it per-call (rather than at hook init) ensures the latest selection is used
+    // and avoids a stale value after toggling. The hook clears the previous
+    // completion and aborts any prior request, so this also covers regenerate.
+    const options =
+      aiOverrideAllowed && requestedMode
+        ? { headers: { [AI_ANALYSIS_MODE_HEADER]: requestedMode } }
+        : undefined;
+    setHasCompleted(false);
+    void complete("", options);
   };
 
-  const handleGenerate = async () => {
-    // Cancel a previous in-flight request (e.g. a rapid regenerate).
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
+  const errorMessage = normalizeError(error);
 
-    setStatus("loading");
-    setText("");
-    setError(null);
-
-    try {
-      const headers: Record<string, string> = {};
-      if (aiOverrideAllowed && requestedMode) {
-        headers[AI_ANALYSIS_MODE_HEADER] = requestedMode;
-      }
-
-      const response = await fetch(`/api/ai-analysis/${symbol}`, {
-        method: "POST",
-        headers,
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => null);
-        throw new Error(data?.error || "Failed to generate analysis");
-      }
-
-      if (!response.body) {
-        throw new Error("No response stream");
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let accumulated = "";
-      let started = false;
-
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        const chunk = decoder.decode(value, { stream: true });
-        if (!chunk) continue;
-        accumulated += chunk;
-        if (!started) {
-          started = true;
-          setStatus("streaming");
-        }
-        setText(accumulated);
-      }
-
-      // Flush any buffered multi-byte character left in the decoder.
-      const tail = decoder.decode();
-      if (tail) {
-        accumulated += tail;
-        setText(accumulated);
-      }
-
-      setStatus("complete");
-    } catch (err) {
-      // A deliberate abort (unmount / regenerate) is not an error to surface.
-      if (err instanceof DOMException && err.name === "AbortError") {
-        return;
-      }
-      setError(err instanceof Error ? err.message : "Something went wrong");
-      setStatus("error");
-    }
-  };
+  const status: Status = errorMessage
+    ? "error"
+    : isLoading && completion.length === 0
+      ? "loading"
+      : isLoading
+        ? "streaming"
+        : completion.length > 0 || hasCompleted
+          ? "complete"
+          : "idle";
 
   if (status === "loading") {
-    return <ShimmerCard className="min-w-[220px]" />;
+    return (
+      <div aria-busy="true">
+        <span className="sr-only" role="status" aria-live="polite">
+          Generating analysis…
+        </span>
+        <ShimmerCard className="min-w-[220px]" />
+      </div>
+    );
   }
 
   if (status === "streaming" || status === "complete") {
     const isStreaming = status === "streaming";
     return (
-      <Card className="glassmorphic min-w-[220px]">
+      <Card
+        className="glassmorphic min-w-[220px]"
+        role="region"
+        aria-labelledby={titleId}
+        aria-busy={isStreaming}
+      >
+        {/* Polite live region announces completion. It stays silent while
+            streaming because the loading state already announced "Generating
+            analysis…" — re-announcing on the loading → streaming transition
+            would double-speak — and reading every streamed token would be noise. */}
+        <span className="sr-only" role="status" aria-live="polite">
+          {isStreaming ? "" : "Analysis ready."}
+        </span>
         <CardHeader>
-          <CardTitle>AI Analysis</CardTitle>
+          <CardTitle id={titleId}>AI Analysis</CardTitle>
           <CardDescription>
             AI-powered insights for {name}
           </CardDescription>
@@ -254,12 +291,15 @@ export function AiAnalysisSection({
             {/* Icon Container */}
             <div className="hidden sm:block flex-shrink-0">
               <div className="flex h-12 w-12 items-center justify-center rounded-full bg-stone-800/40 backdrop-blur-sm ring-1 ring-stone-700/30">
-                <BrainCircuit className="h-6 w-6 text-stone-300" />
+                <BrainCircuit
+                  aria-hidden="true"
+                  className="h-6 w-6 text-stone-300"
+                />
               </div>
             </div>
 
             {/* Analysis Content */}
-            <AnalysisMarkdown>{text}</AnalysisMarkdown>
+            <AnalysisMarkdown>{completion}</AnalysisMarkdown>
           </div>
 
           {/* Footer swaps the streaming indicator for the Regenerate button.
@@ -271,8 +311,7 @@ export function AiAnalysisSection({
               <motion.div
                 key="generating"
                 className="flex items-center gap-2 text-sm text-muted-foreground"
-                role="status"
-                aria-live="polite"
+                aria-hidden="true"
                 exit={{ opacity: 0 }}
                 transition={
                   reduce
@@ -298,7 +337,10 @@ export function AiAnalysisSection({
                 <div className="flex justify-end">
                   <ActionButton onClick={handleGenerate}>
                     Regenerate Analysis
-                    <BrainCircuit className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2" />
+                    <BrainCircuit
+                      aria-hidden="true"
+                      className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2"
+                    />
                   </ActionButton>
                 </div>
               </motion.div>
@@ -310,10 +352,14 @@ export function AiAnalysisSection({
   }
 
   return (
-    <Card className="glassmorphic min-w-[220px]">
+    <Card
+      className="glassmorphic min-w-[220px]"
+      role="region"
+      aria-labelledby={titleId}
+    >
       {/* Header Zone */}
       <CardHeader>
-        <CardTitle>AI Analysis</CardTitle>
+        <CardTitle id={titleId}>AI Analysis</CardTitle>
         <CardDescription>
           Get AI-powered insights and analysis for {name}
         </CardDescription>
@@ -330,7 +376,10 @@ export function AiAnalysisSection({
           {/* Icon Container */}
           <div className="hidden sm:block flex-shrink-0">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-stone-800/40 backdrop-blur-sm ring-1 ring-stone-700/30">
-              <BrainCircuit className="h-6 w-6 text-stone-300" />
+              <BrainCircuit
+                aria-hidden="true"
+                className="h-6 w-6 text-stone-300"
+              />
             </div>
           </div>
 
@@ -395,13 +444,14 @@ export function AiAnalysisSection({
         {/* Button Row */}
         <div className="flex items-center justify-between gap-3">
           {aiOverrideAllowed ? (
-            <ModeToggle value={requestedMode} onChange={updateRequestedMode} />
+            <ModeToggle value={requestedMode} onChange={writeStoredMode} />
           ) : (
             <span />
           )}
           <ActionButton onClick={handleGenerate}>
             {status === "error" ? "Try Again" : "Generate AI Analysis"}
             <BrainCircuit
+              aria-hidden="true"
               className={
                 "size-5 group-hover:translate-x-1 rotate-180 " +
                 "group-hover:rotate-0 transition duration-300 ease-out " +
@@ -411,9 +461,12 @@ export function AiAnalysisSection({
           </ActionButton>
         </div>
 
-        {error && (
-          <div className="mt-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
+        {errorMessage && (
+          <div
+            role="alert"
+            className="mt-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            {errorMessage}
           </div>
         )}
       </CardContent>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.71",
+    "@ai-sdk/react": "^3.0.207",
     "@gsap/react": "^2.1.2",
     "@radix-ui/react-slot": "^1.2.3",
     "ai": "^6.0.205",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.71
         version: 3.0.71(zod@3.25.76)
+      '@ai-sdk/react':
+        specifier: ^3.0.207
+        version: 3.0.207(react@19.2.1)(zod@3.25.76)
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.13.0)(react@19.2.1)
@@ -171,6 +174,12 @@ packages:
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.207':
+    resolution: {integrity: sha512-/wlJv214OQIqUDvoEFO4pqGYCmcXUJMEPcPc+1w2pQhf86onLv7My2+KlsKdK9XGATlI3hHpYaB3MbrpvLDzbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3818,6 +3827,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -3842,6 +3856,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4038,6 +4056,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -4310,6 +4333,16 @@ snapshots:
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.207(react@19.2.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.29(zod@3.25.76)
+      ai: 6.0.205(zod@3.25.76)
+      react: 19.2.1
+      swr: 2.4.1(react@19.2.1)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8547,6 +8580,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.4.1(react@19.2.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.1
+      use-sync-external-store: 1.6.0(react@19.2.1)
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.8:
@@ -8573,6 +8612,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -8798,6 +8839,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
 
   v8-to-istanbul@9.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Implements task **NEU-22**: Create AI Analysis Card Container Component.

**Type:** feat
**Complexity:** M

Brings the AI Analysis card to its full spec on the Vercel AI SDK: the streaming lifecycle and state are now driven by the SDK client hook, and every state change is exposed to assistive technology.

## What was done

- Migrated the client from a hand-rolled `fetch` + `ReadableStream` reader (with ad-hoc `status`/`text`/`error` `useState`) to the AI SDK `useCompletion` hook (`@ai-sdk/react`) with `streamProtocol: 'text'` against the **unchanged** `POST /api/ai-analysis/{symbol}` route. Render state is now derived from `completion`/`isLoading`/`error`.
- Preserved all five states (idle, loading shimmer, streaming, complete, error), regenerate, unmount-abort, and the mock/live mode toggle (now read SSR-safely via `useSyncExternalStore`; the `x-ai-analysis-mode` header is sent per-request). Added `normalizeError` to recover the route's JSON `{ error }` body, which the text protocol surfaces raw.
- Accessibility: `role="region"` + `aria-labelledby`, a single polite `role="status"` live region (announces "Generating…" / "Analysis ready." without double-speaking), `role="alert"` errors, and `aria-hidden` decorative icons.
- Reworked + expanded component tests to 15 cases covering the full state machine, error normalization, mode toggle, unmount-abort, and a11y (100% patch line coverage).

## Done When

- `pnpm preflight` exits 0 (typecheck, eslint `--max-warnings=0`, all Jest tests).
- The component contains no manual `fetch`/`getReader()`/`TextDecoder` loop and no `status`/`text`/`error` `useState`; streaming state comes from `useCompletion`.
- All five states render; the `role="status"` streaming indicator and `role="alert"` error are verified by tests.

Out of scope (tracked separately): relocation to `components/crypto/ai-analysis-card.tsx` (NEU-781).
