### PR TITLE
feat(NEU-781): relocate AI card + lazy/Suspense page integration

### DIFF
--- a/app/details/[symbol]/__tests__/page.test.tsx
+++ b/app/details/[symbol]/__tests__/page.test.tsx
@@ -137,15 +137,29 @@ jest.mock("@/components/crypto/card/trading-activity-card", () => ({
   },
 }));
 
-jest.mock("../_components/ai-analysis-section", () => ({
+jest.mock("@/components/crypto/ai-analysis-card", () => ({
   __esModule: true,
-  AiAnalysisSection: function MockAiAnalysisSection() {
+  AiAnalysisCard: function MockAiAnalysisCard() {
     return (
       <div data-testid="card">
         <div data-testid="card-title">AI Analysis</div>
         <button data-testid="button">Generate AI Analysis</button>
       </div>
     );
+  },
+}));
+
+// The page loads the AI card via `next/dynamic`, which code-splits at runtime.
+// This unit test does not exercise code-splitting, so resolve the dynamic import
+// synchronously to the (mocked) card — keeping rendering synchronous and the
+// Suspense fallback out of the way.
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    const { AiAnalysisCard } = jest.requireMock(
+      "@/components/crypto/ai-analysis-card"
+    );
+    return AiAnalysisCard;
   },
 }));
 
@@ -274,5 +288,26 @@ describe("SymbolDetailsPage", () => {
     expect(screen.getByTestId("crypto-icon")).toBeInTheDocument();
     expect(screen.getByTestId("crypto-sparkline")).toBeInTheDocument();
     expect(screen.getByTestId("button")).toBeInTheDocument();
+  });
+
+  it("renders the lazy AI analysis card below the market data section", async () => {
+    mockFetchAssets.mockResolvedValue([mockAsset]);
+
+    const params = Promise.resolve({ symbol: "btc" });
+    const component = await SymbolDetailsPage({ params });
+    render(component);
+
+    // The lazily-loaded AI card resolves and renders (Suspense fallback is not
+    // shown because the dynamic import resolves synchronously in tests).
+    const marketData = screen.getByTestId("market-data-card");
+    const aiAnalysis = screen.getByText("AI Analysis");
+    expect(marketData).toBeInTheDocument();
+    expect(aiAnalysis).toBeInTheDocument();
+
+    // Placement: the AI card appears after the market-data section in DOM order.
+    expect(
+      marketData.compareDocumentPosition(aiAnalysis) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 });

--- a/app/details/[symbol]/page.tsx
+++ b/app/details/[symbol]/page.tsx
@@ -1,5 +1,6 @@
 import { Asset, fetchAssets } from "@/lib/data/assets";
 import { Suspense } from "react";
+import dynamicImport from "next/dynamic";
 import { notFound } from "next/navigation";
 import {
   Card,
@@ -15,11 +16,18 @@ import { getPriceMovementTextColorClass } from "@/lib/utils/ui-helpers";
 import ShimmerCard from "@/components/ui/shimmer-card";
 import MarketDataCard from "@/components/crypto/card/market-data-card";
 import TradingActivityCard from "@/components/crypto/card/trading-activity-card";
-import { AiAnalysisSection } from "./_components/ai-analysis-section";
 import { getEnv } from "@/lib/env";
 import { isClientOverrideAllowed } from "@/lib/aiAnalysisMode";
 
 export const dynamic = "force-dynamic";
+
+// Lazy-load the AI analysis card so its client bundle (react-markdown, motion,
+// the AI SDK) is code-split out of the initial page payload. `next/dynamic`
+// defaults to `ssr: true`, which is the only mode supported inside a Server
+// Component; the Suspense boundary below shows a ShimmerCard while it loads.
+const AiAnalysisCard = dynamicImport(() =>
+  import("@/components/crypto/ai-analysis-card").then((m) => m.AiAnalysisCard),
+);
 
 interface SymbolDetailsPageProps {
   params: Promise<{ symbol: string }>;
@@ -120,12 +128,15 @@ export default async function SymbolDetailsPage({
           </Suspense>
         </div>
 
-        {/* AI Analysis Section */}
-        <AiAnalysisSection
-          name={asset.name}
-          symbol={asset.symbol}
-          aiOverrideAllowed={aiOverrideAllowed}
-        />
+        {/* AI Analysis Section — lazy-loaded below the market-data grid so it
+            does not block the initial render. */}
+        <Suspense fallback={<ShimmerCard className="min-w-[220px]" />}>
+          <AiAnalysisCard
+            name={asset.name}
+            symbol={asset.symbol}
+            aiOverrideAllowed={aiOverrideAllowed}
+          />
+        </Suspense>
       </div>
     </main>
   );

--- a/components/crypto/__tests__/ai-analysis-card.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-card.test.tsx
@@ -56,7 +56,7 @@ jest.mock("@ai-sdk/react", () => {
   };
 });
 
-import { AiAnalysisSection } from "../ai-analysis-section";
+import { AiAnalysisCard } from "@/components/crypto/ai-analysis-card";
 import {
   AI_ANALYSIS_MODE_HEADER,
   AI_ANALYSIS_MODE_STORAGE_KEY,
@@ -74,7 +74,7 @@ function setHook(
   });
 }
 
-describe("AiAnalysisSection", () => {
+describe("AiAnalysisCard", () => {
   beforeEach(() => {
     mockHookState.completion = "";
     mockHookState.isLoading = false;
@@ -92,13 +92,13 @@ describe("AiAnalysisSection", () => {
   });
 
   it("points the hook at the per-symbol route using the text stream protocol", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     expect(mockCapturedOptions.api).toBe("/api/ai-analysis/BTC");
     expect(mockCapturedOptions.streamProtocol).toBe("text");
   });
 
   it("renders the idle empty state with a Generate button", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
 
     expect(
       screen.getByRole("region", { name: /ai analysis/i }),
@@ -110,7 +110,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("triggers a generation with an empty prompt and no mode header by default", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
 
     expect(
       screen.queryByRole("group", { name: /inference mode/i }),
@@ -124,7 +124,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("shows the shimmer loading state with a polite status while awaiting the first token", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: true, completion: "" });
 
     const status = screen.getByRole("status");
@@ -136,7 +136,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("renders streaming markdown progressively inside a labelled region", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: true, completion: "## Market Bias\nBullish momentum" });
 
     expect(
@@ -152,7 +152,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("reveals the complete analysis with a Regenerate button and an announcement", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: true, completion: "Bullish momentum building." });
     setHook(
       { isLoading: false, completion: "Bullish momentum building." },
@@ -167,7 +167,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("regenerates: clicking Regenerate triggers another generation", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: false, completion: "Some analysis." }, { finish: true });
 
     fireEvent.click(
@@ -178,7 +178,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("treats a finished-but-empty stream as complete, not idle", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     // A successful stream that emitted no text still resolves to the complete
     // card (Regenerate available) rather than silently reverting to idle.
     setHook({ isLoading: true, completion: "" });
@@ -193,7 +193,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("normalizes a JSON error body and surfaces it as an alert with Try Again", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     // The AI SDK text protocol surfaces the route's JSON `{ error }` body
     // verbatim in `error.message`; the component recovers the message.
     setHook({
@@ -209,7 +209,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("falls back to the raw message for a non-JSON (mid-stream) error", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({
       isLoading: false,
       completion: "Partial analysis ",
@@ -223,14 +223,14 @@ describe("AiAnalysisSection", () => {
   });
 
   it("shows a generic message for an error with no message text", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: false, error: new Error("") });
 
     expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
   });
 
   it("falls back to the raw text for a JSON error body without an error field", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({
       isLoading: false,
       error: new Error(JSON.stringify({ message: "nope" })),
@@ -241,7 +241,7 @@ describe("AiAnalysisSection", () => {
 
   it("renders the toggle and sends the stored mode header when override is allowed", () => {
     window.localStorage.setItem(AI_ANALYSIS_MODE_STORAGE_KEY, "mock");
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
 
     expect(
       screen.getByRole("group", { name: /inference mode/i }),
@@ -257,7 +257,7 @@ describe("AiAnalysisSection", () => {
   });
 
   it("persists the selected mode and sends it after toggling", () => {
-    render(<AiAnalysisSection name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" aiOverrideAllowed />);
 
     const mockButton = screen.getByRole("button", { name: /^mock$/i });
     fireEvent.click(mockButton);
@@ -277,7 +277,7 @@ describe("AiAnalysisSection", () => {
 
   it("aborts the in-flight stream on unmount", () => {
     const { unmount } = render(
-      <AiAnalysisSection name="Bitcoin" symbol="BTC" />,
+      <AiAnalysisCard name="Bitcoin" symbol="BTC" />,
     );
     setHook({ isLoading: true, completion: "partial" });
 

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -22,7 +22,7 @@ import {
   type AiAnalysisMode,
 } from "@/lib/aiAnalysisMode";
 
-interface AiAnalysisSectionProps {
+interface AiAnalysisCardProps {
   name: string;
   symbol: string;
   /**
@@ -184,11 +184,11 @@ function ModeToggle({
   );
 }
 
-export function AiAnalysisSection({
+export function AiAnalysisCard({
   name,
   symbol,
   aiOverrideAllowed = false,
-}: AiAnalysisSectionProps) {
+}: AiAnalysisCardProps) {
   const requestedMode = useSyncExternalStore(
     subscribeStoredMode,
     readStoredMode,


### PR DESCRIPTION
## Summary

Implements task **NEU-781**: relocate the AI analysis card to the shared crypto components directory and integrate it into the details page with lazy-loading + a Suspense boundary.

**Type:** feat
**Complexity:** M

## What was done

- Moved `app/details/[symbol]/_components/ai-analysis-section.tsx` → `components/crypto/ai-analysis-card.tsx`, renaming the export `AiAnalysisSection` → `AiAnalysisCard` (and its props interface). Behavior unchanged; all internal imports are `@/`-absolute so no rewrites were needed.
- Moved the card's unit test alongside it (`components/crypto/__tests__/ai-analysis-card.test.tsx`).
- `app/details/[symbol]/page.tsx` now loads the card via `next/dynamic` (imported as `dynamicImport` to avoid colliding with the existing `export const dynamic = "force-dynamic"`) at the default `ssr: true`, wrapped in a `Suspense` boundary with a `ShimmerCard` fallback — matching the existing `MarketDataCard`/`TradingActivityCard` pattern and keeping the card below the market-data grid.
- Updated the page test to mock the new card path and `next/dynamic`, and added a DOM-order assertion that the AI card renders below the market-data section.

## Done When

- `pnpm preflight` exits 0 (typecheck + eslint `--max-warnings=0` + Jest). ✅ 261 passed / 1 skipped.
- `components/crypto/ai-analysis-card.tsx` exports `AiAnalysisCard`; `page.tsx` imports it via `next/dynamic` inside a `Suspense` boundary. ✅
- No `ai-analysis-section` references remain in `app`/`components`. ✅

## Note

The "visual regression / screenshot check" acceptance item is covered by the page-test placement assertion plus manual QA screenshots — no committed visual-snapshot tooling exists in this Jest-only project. Follow-up: `docs/AI-Analysis-Architecture-Review.md` still references the old `ai-analysis-section` path.
