### PR TITLE
feat(NEU-23): redesign the AI analysis loading skeleton

### DIFF
--- a/app/details/[symbol]/page.tsx
+++ b/app/details/[symbol]/page.tsx
@@ -14,6 +14,7 @@ import { CryptoSparkline } from "@/components/crypto/crypto-sparkline";
 import { formatNumber, formatPercent } from "@/lib/utils/numbers";
 import { getPriceMovementTextColorClass } from "@/lib/utils/ui-helpers";
 import ShimmerCard from "@/components/ui/shimmer-card";
+import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
 import MarketDataCard from "@/components/crypto/card/market-data-card";
 import TradingActivityCard from "@/components/crypto/card/trading-activity-card";
 import { getEnv } from "@/lib/env";
@@ -24,7 +25,7 @@ export const dynamic = "force-dynamic";
 // Lazy-load the AI analysis card so its client bundle (react-markdown, motion,
 // the AI SDK) is code-split out of the initial page payload. `next/dynamic`
 // defaults to `ssr: true`, which is the only mode supported inside a Server
-// Component; the Suspense boundary below shows a ShimmerCard while it loads.
+// Component; the Suspense boundary below shows an AiAnalysisShimmer while it loads.
 const AiAnalysisCard = dynamicImport(() =>
   import("@/components/crypto/ai-analysis-card").then((m) => m.AiAnalysisCard),
 );
@@ -130,7 +131,7 @@ export default async function SymbolDetailsPage({
 
         {/* AI Analysis Section — lazy-loaded below the market-data grid so it
             does not block the initial render. */}
-        <Suspense fallback={<ShimmerCard className="min-w-[220px]" />}>
+        <Suspense fallback={<AiAnalysisShimmer />}>
           <AiAnalysisCard
             name={asset.name}
             symbol={asset.symbol}

--- a/app/globals.css
+++ b/app/globals.css
@@ -129,6 +129,24 @@
   --text-shadow-outline: 1px 0 0 var(--tw-text-shadow-color),
     -1px 0 0 var(--tw-text-shadow-color), 0 1px 0 var(--tw-text-shadow-color),
     0 -1px 0 var(--tw-text-shadow-color);
+
+  /* "Thinking" spin for the generating icon: an eased full turn that slows at
+     each loop seam (ease-in-out) while the icon breathes larger at the half-turn
+     — reads as inhale-spin-exhale, not a mechanical linear spinner. */
+  --animate-icon-thinking: iconThinking 2.2s cubic-bezier(0.65, 0, 0.35, 1)
+    infinite;
+}
+
+@keyframes iconThinking {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.18);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
 }
 
 @utility border-outset {

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,25 @@
   }
 }
 
+/* Continuous shine sweep for the ActionButton's loading state (mirrors the
+   hover sweep, looped) — signals "working" on the muted Generating button. */
+@keyframes shimmerSweep {
+  0% {
+    transform: translateX(-120%) skewX(-20deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(360%) skewX(-20deg);
+    opacity: 0;
+  }
+}
+
 /* Loading rings animation for page transitions */
 @keyframes expandFade {
   0% {

--- a/components/crypto/__tests__/ai-analysis-card.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-card.test.tsx
@@ -123,9 +123,12 @@ describe("AiAnalysisCard", () => {
     expect(mockComplete).toHaveBeenCalledWith("", undefined);
   });
 
-  it("shows the shimmer loading state with a polite status while awaiting the first token", () => {
+  it("shows the AI-shaped shimmer loading state with a polite status while awaiting the first token", () => {
     render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
     setHook({ isLoading: true, completion: "" });
+
+    // The dedicated AI skeleton renders — not the generic crypto ShimmerCard.
+    expect(screen.getByTestId("ai-analysis-shimmer")).toBeInTheDocument();
 
     const status = screen.getByRole("status");
     expect(status).toHaveTextContent(/generating analysis/i);

--- a/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
@@ -1,14 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import {
-  AiAnalysisShimmer,
-  AI_CARD_MIN_H,
-} from "@/components/crypto/ai-analysis-shimmer";
+import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
 
-// The min-height floor is the first class in the shared token; any one of its
-// classes is enough to detect that the floor was applied.
-const MIN_H_CLASS = AI_CARD_MIN_H.split(" ")[0];
+// The base-breakpoint floor value; present in the generating skeleton's height
+// class (`h-[680px]`) and absent from the compact neutral fallback.
+const FLOOR_TOKEN = "680px";
 
 describe("AiAnalysisShimmer", () => {
   it("renders the AI-shaped skeleton with aria-busy", () => {
@@ -37,16 +34,17 @@ describe("AiAnalysisShimmer", () => {
     expect(screen.queryByText(/generating analysis/i)).not.toBeInTheDocument();
   });
 
-  it("carries the no-shrink min-height floor only in the generating variant", () => {
+  it("carries the no-shrink height floor only in the generating variant", () => {
     // The generating skeleton follows the (taller) idle state, so it must hold
-    // the floor to avoid shrinking; the neutral fallback precedes idle and
-    // should stay compact and grow into it.
+    // the height floor to avoid shrinking; the neutral fallback precedes idle
+    // and should stay compact and grow into it.
     const { container, rerender } = render(
       <AiAnalysisShimmer footer="generating" />,
     );
-    expect(container.querySelector(`.${CSS.escape(MIN_H_CLASS)}`)).not.toBeNull();
+    const card = () => container.querySelector('[data-slot="card"]');
+    expect(card()?.className).toContain(FLOOR_TOKEN);
 
     rerender(<AiAnalysisShimmer footer="neutral" />);
-    expect(container.querySelector(`.${CSS.escape(MIN_H_CLASS)}`)).toBeNull();
+    expect(card()?.className ?? "").not.toContain(FLOOR_TOKEN);
   });
 });

--- a/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
+import {
+  AiAnalysisShimmer,
+  AI_CARD_MIN_H,
+} from "@/components/crypto/ai-analysis-shimmer";
+
+// The min-height floor is the first class in the shared token; any one of its
+// classes is enough to detect that the floor was applied.
+const MIN_H_CLASS = AI_CARD_MIN_H.split(" ")[0];
 
 describe("AiAnalysisShimmer", () => {
   it("renders the AI-shaped skeleton with aria-busy", () => {
@@ -28,5 +35,18 @@ describe("AiAnalysisShimmer", () => {
 
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText(/generating analysis/i)).not.toBeInTheDocument();
+  });
+
+  it("carries the no-shrink min-height floor only in the generating variant", () => {
+    // The generating skeleton follows the (taller) idle state, so it must hold
+    // the floor to avoid shrinking; the neutral fallback precedes idle and
+    // should stay compact and grow into it.
+    const { container, rerender } = render(
+      <AiAnalysisShimmer footer="generating" />,
+    );
+    expect(container.querySelector(`.${CSS.escape(MIN_H_CLASS)}`)).not.toBeNull();
+
+    rerender(<AiAnalysisShimmer footer="neutral" />);
+    expect(container.querySelector(`.${CSS.escape(MIN_H_CLASS)}`)).toBeNull();
   });
 });

--- a/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-shimmer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
+
+describe("AiAnalysisShimmer", () => {
+  it("renders the AI-shaped skeleton with aria-busy", () => {
+    render(<AiAnalysisShimmer />);
+
+    const root = screen.getByTestId("ai-analysis-shimmer");
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("announces via a polite status only in the generating variant", () => {
+    const { rerender } = render(<AiAnalysisShimmer footer="generating" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(/generating analysis/i);
+
+    // The neutral default makes no claim — it resolves into the idle card, so
+    // announcing "generating" would be false.
+    rerender(<AiAnalysisShimmer footer="neutral" />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("defaults to the neutral footer with no announcement", () => {
+    render(<AiAnalysisShimmer />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText(/generating analysis/i)).not.toBeInTheDocument();
+  });
+});

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/card";
 import { ActionButton } from "@/components/ui/action-button";
 import { BrainCircuit } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import type { Components } from "react-markdown";
 import {
@@ -203,11 +202,6 @@ export function AiAnalysisCard({
   // text, so an empty-but-successful response still reveals the completed card
   // (matching the pre-migration behavior) instead of silently reverting to idle.
   const [hasCompleted, setHasCompleted] = useState(false);
-  // Tracks whether the Regenerate button's reveal (height grow) has finished, so
-  // the wrapper can clip during the grow but switch to `overflow: visible` after
-  // — otherwise the persistent clip cuts the button's hover translate / shadow.
-  const [regenRevealed, setRegenRevealed] = useState(false);
-  const reduce = useReducedMotion();
   const titleId = useId();
 
   // The AI SDK hook owns the streaming lifecycle: `completion` accumulates the
@@ -241,8 +235,6 @@ export function AiAnalysisCard({
         ? { headers: { [AI_ANALYSIS_MODE_HEADER]: requestedMode } }
         : undefined;
     setHasCompleted(false);
-    // Re-arm the reveal clip so the next streaming → complete grows in cleanly.
-    setRegenRevealed(false);
     void complete("", options);
   };
 
@@ -309,60 +301,27 @@ export function AiAnalysisCard({
             <AnalysisMarkdown>{completion}</AnalysisMarkdown>
           </div>
 
-          {/* Footer swaps the streaming indicator for the Regenerate button.
-              Both states share one CSS grid cell (`col/row-start-1`), so the
-              footer height always tracks the taller child: on streaming →
-              complete the indicator cross-fades out while the button row grows
-              in (height 0 → auto), easing the card taller monotonically — no
-              overshoot, no dip. Collapses to an instant swap under reduced
-              motion. */}
-          <div className="grid">
-            <AnimatePresence initial={false}>
-              {isStreaming ? (
-                <motion.div
-                  key="generating"
-                  className="col-start-1 row-start-1 flex items-center justify-end gap-2 text-sm text-muted-foreground"
-                  aria-hidden="true"
-                  exit={{ opacity: 0 }}
-                  transition={
-                    reduce
-                      ? { duration: 0 }
-                      : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }
-                  }
-                >
-                  <BrainCircuit className="size-4 animate-pulse" />
-                  <span className="animate-pulse">Generating analysis…</span>
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="regenerate"
-                  className="col-start-1 row-start-1"
-                  // Clip only while the row grows in; once revealed, switch to
-                  // visible so the button's hover translate and shadow aren't cut.
-                  style={{
-                    overflow: regenRevealed || reduce ? undefined : "hidden",
-                  }}
-                  initial={reduce ? false : { height: 0, opacity: 0 }}
-                  animate={{ height: "auto", opacity: 1 }}
-                  onAnimationComplete={() => setRegenRevealed(true)}
-                  transition={
-                    reduce
-                      ? { duration: 0 }
-                      : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
-                  }
-                >
-                  <div className="flex justify-end">
-                    <ActionButton onClick={handleGenerate}>
-                      Regenerate Analysis
-                      <BrainCircuit
-                        aria-hidden="true"
-                        className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2"
-                      />
-                    </ActionButton>
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
+          {/* One button for both states: a muted, animated "Generating
+              analysis…" while streaming that morphs into the active Regenerate
+              CTA on completion — same element, same position, fixed height, so
+              there is no layout shift on the streaming → complete transition. */}
+          <div className="flex justify-end">
+            <ActionButton
+              loading={isStreaming}
+              onClick={handleGenerate}
+              aria-hidden={isStreaming || undefined}
+            >
+              {isStreaming ? "Generating analysis…" : "Regenerate Analysis"}
+              <BrainCircuit
+                aria-hidden="true"
+                className={cn(
+                  "size-5",
+                  isStreaming
+                    ? "animate-pulse motion-reduce:animate-none"
+                    : "rotate-180 transition duration-300 ease-out group-hover:translate-x-1 group-hover:rotate-0 group-active:translate-x-2",
+                )}
+              />
+            </ActionButton>
           </div>
         </CardContent>
       </Card>

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -13,7 +13,7 @@ import { BrainCircuit } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import type { Components } from "react-markdown";
-import ShimmerCard from "@/components/ui/shimmer-card";
+import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
 import Markdown from "react-markdown";
 import { useCompletion } from "@ai-sdk/react";
 import {
@@ -249,14 +249,7 @@ export function AiAnalysisCard({
           : "idle";
 
   if (status === "loading") {
-    return (
-      <div aria-busy="true">
-        <span className="sr-only" role="status" aria-live="polite">
-          Generating analysis…
-        </span>
-        <ShimmerCard className="min-w-[220px]" />
-      </div>
-    );
+    return <AiAnalysisShimmer footer="generating" />;
   }
 
   if (status === "streaming" || status === "complete") {

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -283,8 +283,12 @@ export function AiAnalysisCard({
             </span>
           </CardAction>
         </CardHeader>
-        <CardContent className="px-4 sm:px-6">
-          <div className="flex items-start gap-4 sm:gap-6 mb-6">
+        <CardContent className="flex flex-1 flex-col px-4 sm:px-6">
+          {/* Content row grows to fill the reserved height so the footer below
+              stays pinned to the bottom — the "Generating analysis…" indicator
+              holds the same position from the loading skeleton through streaming
+              instead of jumping up to sit under the first token. */}
+          <div className="flex flex-1 items-start gap-4 sm:gap-6 mb-6">
             {/* Icon Container */}
             <div className="hidden sm:block flex-shrink-0">
               <div className="flex h-12 w-12 items-center justify-center rounded-full bg-stone-800/40 backdrop-blur-sm ring-1 ring-stone-700/30">

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -203,6 +203,10 @@ export function AiAnalysisCard({
   // text, so an empty-but-successful response still reveals the completed card
   // (matching the pre-migration behavior) instead of silently reverting to idle.
   const [hasCompleted, setHasCompleted] = useState(false);
+  // Tracks whether the Regenerate button's reveal (height grow) has finished, so
+  // the wrapper can clip during the grow but switch to `overflow: visible` after
+  // — otherwise the persistent clip cuts the button's hover translate / shadow.
+  const [regenRevealed, setRegenRevealed] = useState(false);
   const reduce = useReducedMotion();
   const titleId = useId();
 
@@ -237,6 +241,8 @@ export function AiAnalysisCard({
         ? { headers: { [AI_ANALYSIS_MODE_HEADER]: requestedMode } }
         : undefined;
     setHasCompleted(false);
+    // Re-arm the reveal clip so the next streaming → complete grows in cleanly.
+    setRegenRevealed(false);
     void complete("", options);
   };
 
@@ -304,49 +310,60 @@ export function AiAnalysisCard({
           </div>
 
           {/* Footer swaps the streaming indicator for the Regenerate button.
-              On streaming → complete the indicator fades out while the button
-              row grows in (height 0 → auto), easing the card taller. Collapses
-              to an instant swap when reduced motion is requested. */}
-          <AnimatePresence initial={false}>
-            {isStreaming ? (
-              <motion.div
-                key="generating"
-                className="flex items-center gap-2 text-sm text-muted-foreground"
-                aria-hidden="true"
-                exit={{ opacity: 0 }}
-                transition={
-                  reduce
-                    ? { duration: 0 }
-                    : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }
-                }
-              >
-                <BrainCircuit className="size-4 animate-pulse" />
-                <span className="animate-pulse">Generating analysis…</span>
-              </motion.div>
-            ) : (
-              <motion.div
-                key="regenerate"
-                style={{ overflow: "hidden" }}
-                initial={reduce ? false : { height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                transition={
-                  reduce
-                    ? { duration: 0 }
-                    : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
-                }
-              >
-                <div className="flex justify-end">
-                  <ActionButton onClick={handleGenerate}>
-                    Regenerate Analysis
-                    <BrainCircuit
-                      aria-hidden="true"
-                      className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2"
-                    />
-                  </ActionButton>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+              Both states share one CSS grid cell (`col/row-start-1`), so the
+              footer height always tracks the taller child: on streaming →
+              complete the indicator cross-fades out while the button row grows
+              in (height 0 → auto), easing the card taller monotonically — no
+              overshoot, no dip. Collapses to an instant swap under reduced
+              motion. */}
+          <div className="grid">
+            <AnimatePresence initial={false}>
+              {isStreaming ? (
+                <motion.div
+                  key="generating"
+                  className="col-start-1 row-start-1 flex items-center gap-2 text-sm text-muted-foreground"
+                  aria-hidden="true"
+                  exit={{ opacity: 0 }}
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }
+                  }
+                >
+                  <BrainCircuit className="size-4 animate-pulse" />
+                  <span className="animate-pulse">Generating analysis…</span>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="regenerate"
+                  className="col-start-1 row-start-1"
+                  // Clip only while the row grows in; once revealed, switch to
+                  // visible so the button's hover translate and shadow aren't cut.
+                  style={{
+                    overflow: regenRevealed || reduce ? undefined : "hidden",
+                  }}
+                  initial={reduce ? false : { height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  onAnimationComplete={() => setRegenRevealed(true)}
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
+                  }
+                >
+                  <div className="flex justify-end">
+                    <ActionButton onClick={handleGenerate}>
+                      Regenerate Analysis
+                      <BrainCircuit
+                        aria-hidden="true"
+                        className="size-5 group-hover:translate-x-1 rotate-180 group-hover:rotate-0 transition duration-300 ease-out group-active:translate-x-2"
+                      />
+                    </ActionButton>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
         </CardContent>
       </Card>
     );

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -321,7 +321,7 @@ export function AiAnalysisCard({
               {isStreaming ? (
                 <motion.div
                   key="generating"
-                  className="col-start-1 row-start-1 flex items-center gap-2 text-sm text-muted-foreground"
+                  className="col-start-1 row-start-1 flex items-center justify-end gap-2 text-sm text-muted-foreground"
                   aria-hidden="true"
                   exit={{ opacity: 0 }}
                   transition={

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -312,15 +312,18 @@ export function AiAnalysisCard({
               aria-hidden={isStreaming || undefined}
             >
               {isStreaming ? "Generating analysis…" : "Regenerate Analysis"}
-              <BrainCircuit
-                aria-hidden="true"
-                className={cn(
-                  "size-5",
-                  isStreaming
-                    ? "animate-pulse motion-reduce:animate-none"
-                    : "rotate-180 transition duration-300 ease-out group-hover:translate-x-1 group-hover:rotate-0 group-active:translate-x-2",
-                )}
-              />
+              {isStreaming ? (
+                // Animate an HTML wrapper (not the <svg> directly) — CSS
+                // transform animations on SVG elements are unreliable.
+                <span className="inline-flex animate-icon-thinking motion-reduce:animate-none">
+                  <BrainCircuit aria-hidden="true" className="size-5" />
+                </span>
+              ) : (
+                <BrainCircuit
+                  aria-hidden="true"
+                  className="size-5 rotate-180 transition duration-300 ease-out group-hover:translate-x-1 group-hover:rotate-0 group-active:translate-x-2"
+                />
+              )}
             </ActionButton>
           </div>
         </CardContent>

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -311,7 +311,32 @@ export function AiAnalysisCard({
               onClick={handleGenerate}
               aria-hidden={isStreaming || undefined}
             >
-              {isStreaming ? "Generating analysis…" : "Regenerate Analysis"}
+              {/* Both labels share one grid cell so the button width stays
+                  constant across the streaming → complete morph (no width snap)
+                  and the label cross-fades. Self-sizes to the wider label at any
+                  breakpoint — no hardcoded width. */}
+              <span className="grid place-items-center">
+                <span
+                  aria-hidden={!isStreaming}
+                  style={{ gridArea: "1 / 1" }}
+                  className={cn(
+                    "transition-opacity duration-300",
+                    isStreaming ? "opacity-100" : "opacity-0",
+                  )}
+                >
+                  Generating analysis…
+                </span>
+                <span
+                  aria-hidden={isStreaming || undefined}
+                  style={{ gridArea: "1 / 1" }}
+                  className={cn(
+                    "transition-opacity duration-300",
+                    isStreaming ? "opacity-0" : "opacity-100",
+                  )}
+                >
+                  Regenerate Analysis
+                </span>
+              </span>
               {isStreaming ? (
                 // Animate an HTML wrapper (not the <svg> directly) — CSS
                 // transform animations on SVG elements are unreliable.

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -13,7 +13,11 @@ import { BrainCircuit } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import type { Components } from "react-markdown";
-import { AiAnalysisShimmer } from "@/components/crypto/ai-analysis-shimmer";
+import {
+  AiAnalysisShimmer,
+  AI_CARD_MIN_H,
+} from "@/components/crypto/ai-analysis-shimmer";
+import { cn } from "@/lib/utils/utils";
 import Markdown from "react-markdown";
 import { useCompletion } from "@ai-sdk/react";
 import {
@@ -256,7 +260,7 @@ export function AiAnalysisCard({
     const isStreaming = status === "streaming";
     return (
       <Card
-        className="glassmorphic min-w-[220px]"
+        className={cn("glassmorphic min-w-[220px]", AI_CARD_MIN_H)}
         role="region"
         aria-labelledby={titleId}
         aria-busy={isStreaming}

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -1,0 +1,113 @@
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
+import { BrainCircuit } from "lucide-react";
+import { cn } from "@/lib/utils/utils";
+
+interface AiAnalysisShimmerProps {
+  /**
+   * Footer affordance:
+   * - `"generating"` — the pulsing "Generating analysis…" indicator plus an
+   *   `sr-only` polite live-region announcement. Used by the in-component
+   *   loading state, where a request is genuinely in flight before the first
+   *   streamed token.
+   * - `"neutral"` (default) — a neutral shimmer bar with no announcement. Used
+   *   by the Suspense fallback, which resolves into the card's idle/empty state;
+   *   announcing "Generating…" there would be a false claim.
+   */
+  footer?: "generating" | "neutral";
+  className?: string;
+}
+
+// Reuse the ShimmerCard idiom — `bg-gray-400 rounded opacity-30` bars — so the
+// AI skeleton reads as the same visual family. The pulse lives on the Card
+// wrapper (as in ShimmerCard) and is suppressed under `prefers-reduced-motion`.
+function Bar({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("rounded bg-gray-400 opacity-30", className)}
+    />
+  );
+}
+
+/**
+ * Loading skeleton for the AI analysis card. Its silhouette mirrors the
+ * streaming/complete branch of `AiAnalysisCard` (glassmorphic card → header with
+ * title/subtitle/Beta placeholders → an avatar bubble beside a multi-line text
+ * body) so the skeleton → content handoff produces no structural jump. Unlike
+ * the generic `ShimmerCard`, it carries no price sparkline.
+ */
+export function AiAnalysisShimmer({
+  footer = "neutral",
+  className,
+}: AiAnalysisShimmerProps) {
+  const isGenerating = footer === "generating";
+
+  return (
+    <div aria-busy="true" data-testid="ai-analysis-shimmer">
+      {isGenerating && (
+        <span className="sr-only" role="status" aria-live="polite">
+          Generating analysis…
+        </span>
+      )}
+      <Card
+        className={cn(
+          "glassmorphic min-w-[220px] animate-pulse motion-reduce:animate-none",
+          className,
+        )}
+      >
+        {/* Header — title / subtitle / Beta pill placeholders. Mirrors the real
+            header's grid (CardAction switches it to a two-column layout). */}
+        <CardHeader>
+          <div className="flex flex-col gap-1.5">
+            <Bar className="h-5 w-28" />
+            <Bar className="h-4 w-44" />
+          </div>
+          {/* Real CardAction so CardHeader's `has-data-[slot=card-action]`
+              two-column grid resolves identically to the streaming card. */}
+          <CardAction>
+            <Bar className="h-5 w-10 rounded-full" />
+          </CardAction>
+        </CardHeader>
+
+        <CardContent className="px-4 sm:px-6">
+          {/* Content row — 12×12 avatar bubble + varied-width text lines, using
+              the streaming card's exact spacing so there is no layout shift. */}
+          <div className="flex items-start gap-4 sm:gap-6 mb-6">
+            <div className="hidden sm:block flex-shrink-0">
+              <Bar className="h-12 w-12 rounded-full" />
+            </div>
+            <div className="flex-1 space-y-3">
+              <Bar className="h-4 w-full" />
+              <Bar className="h-4 w-11/12" />
+              <Bar className="h-4 w-4/5" />
+              <Bar className="h-4 w-2/3" />
+            </div>
+          </div>
+
+          {/* Footer — pulsing "Generating analysis…" indicator (mirrors the
+              streaming footer) or a neutral button-shaped shimmer bar. */}
+          {isGenerating ? (
+            <div
+              aria-hidden="true"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <BrainCircuit className="size-4" />
+              <span>Generating analysis…</span>
+            </div>
+          ) : (
+            <div className="flex justify-end">
+              <Bar className="h-9 w-40" />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default AiAnalysisShimmer;

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -145,7 +145,7 @@ export function AiAnalysisShimmer({
           {isGenerating ? (
             <div
               aria-hidden="true"
-              className="flex items-center gap-2 text-sm text-muted-foreground"
+              className="flex items-center justify-end gap-2 text-sm text-muted-foreground"
             >
               <BrainCircuit className="size-4" />
               <span>Generating analysis…</span>

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -33,6 +33,14 @@ interface AiAnalysisShimmerProps {
 // `ai-analysis-card.tsx` changes materially, re-measure and update these.
 export const AI_CARD_MIN_H = "min-h-[680px] sm:min-h-[510px] lg:min-h-[400px]";
 
+// Evenly spaced text-line bars (gray-400 @ 30% — the ShimmerCard idiom) that
+// FILL whatever height they're given, so the generating skeleton is as large as
+// the idle text it stands in for, with no empty void below the lines. A
+// repeating gradient fills any height/width without guessing a line count:
+// 16px bar + 12px gap = 28px period (matches the old `h-4` + `space-y-3` rhythm).
+const LINE_FILL =
+  "repeating-linear-gradient(to bottom, rgb(156 163 175 / 0.3) 0 16px, transparent 16px 28px)";
+
 // Reuse the ShimmerCard idiom — `bg-gray-400 rounded opacity-30` bars — so the
 // AI skeleton reads as the same visual family. The pulse lives on the Card
 // wrapper (as in ShimmerCard) and is suppressed under `prefers-reduced-motion`.
@@ -89,19 +97,32 @@ export function AiAnalysisShimmer({
           </CardAction>
         </CardHeader>
 
-        <CardContent className="px-4 sm:px-6">
-          {/* Content row — 12×12 avatar bubble + varied-width text lines, using
-              the streaming card's exact spacing so there is no layout shift. */}
-          <div className="flex items-start gap-4 sm:gap-6 mb-6">
+        <CardContent className="flex flex-1 flex-col px-4 sm:px-6">
+          {/* Content row — 12×12 avatar bubble + text-line body, using the
+              streaming card's exact spacing so there is no layout shift. The row
+              grows to fill the reserved height. */}
+          <div className="flex flex-1 items-start gap-4 sm:gap-6 mb-6">
             <div className="hidden sm:block flex-shrink-0">
               <Bar className="h-12 w-12 rounded-full" />
             </div>
-            <div className="flex-1 space-y-3">
-              <Bar className="h-4 w-full" />
-              <Bar className="h-4 w-11/12" />
-              <Bar className="h-4 w-4/5" />
-              <Bar className="h-4 w-2/3" />
-            </div>
+            {isGenerating ? (
+              // Fill the reserved height with line bars so the skeleton is as
+              // large as the idle text (no void below the lines).
+              <div
+                aria-hidden="true"
+                className="flex-1 self-stretch"
+                style={{ backgroundImage: LINE_FILL }}
+              />
+            ) : (
+              // Compact body — the neutral fallback stays small and grows into
+              // the idle state it resolves to.
+              <div className="flex-1 space-y-3">
+                <Bar className="h-4 w-full" />
+                <Bar className="h-4 w-11/12" />
+                <Bar className="h-4 w-4/5" />
+                <Bar className="h-4 w-2/3" />
+              </div>
+            )}
           </div>
 
           {/* Footer — pulsing "Generating analysis…" indicator (mirrors the

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -105,11 +105,14 @@ export function AiAnalysisShimmer({
           </CardAction>
         </CardHeader>
 
-        <CardContent className="flex flex-1 flex-col px-4 sm:px-6">
+        {/* `min-h-0` + `overflow-hidden` so the fill grid shrinks to the card's
+            fixed height and clips inside it — without `min-h-0` the flex chain
+            keeps its content's natural height and overflows past the card. */}
+        <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 sm:px-6">
           {/* Content row — 12×12 avatar bubble + text-line body, using the
               streaming card's exact spacing so there is no layout shift. The row
               grows to fill the reserved height. */}
-          <div className="flex flex-1 items-start gap-4 sm:gap-6 mb-6">
+          <div className="flex min-h-0 flex-1 items-start gap-4 sm:gap-6 mb-6">
             <div className="hidden sm:block flex-shrink-0">
               <Bar className="h-12 w-12 rounded-full" />
             </div>

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -150,7 +150,9 @@ export function AiAnalysisShimmer({
             <div className="flex justify-end" aria-hidden="true">
               <ActionButton loading>
                 Generating analysis…
-                <BrainCircuit className="size-5 animate-pulse motion-reduce:animate-none" />
+                <span className="inline-flex animate-icon-thinking motion-reduce:animate-none">
+                  <BrainCircuit className="size-5" />
+                </span>
               </ActionButton>
             </div>
           ) : (

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -33,13 +33,21 @@ interface AiAnalysisShimmerProps {
 // `ai-analysis-card.tsx` changes materially, re-measure and update these.
 export const AI_CARD_MIN_H = "min-h-[680px] sm:min-h-[510px] lg:min-h-[400px]";
 
-// Evenly spaced text-line bars (gray-400 @ 30% — the ShimmerCard idiom) that
-// FILL whatever height they're given, so the generating skeleton is as large as
-// the idle text it stands in for, with no empty void below the lines. A
-// repeating gradient fills any height/width without guessing a line count:
-// 16px bar + 12px gap = 28px period (matches the old `h-4` + `space-y-3` rhythm).
-const LINE_FILL =
-  "repeating-linear-gradient(to bottom, rgb(156 163 175 / 0.3) 0 16px, transparent 16px 28px)";
+// The generating skeleton uses a FIXED height (not just a floor) — same
+// per-breakpoint values as AI_CARD_MIN_H — so the line-fill grid below has a
+// definite height to lay out whole rows against (CSS `auto-fill` can't resolve
+// against an indefinite `min-height`). It is still ≥ the idle height, so the
+// skeleton only ever grows from idle. Keep these values in sync with
+// AI_CARD_MIN_H.
+const AI_SHIMMER_H = "h-[680px] sm:h-[510px] lg:h-[400px]";
+
+// A body that fills its height with WHOLE text-line bars (no clipped half-line)
+// so the generating skeleton is as large as the idle text it stands in for. CSS
+// grid `auto-fill` lays out as many 1rem (16px) line rows as fully fit, with a
+// 12px gap; any leftover (< one line) stays empty at the bottom. Extra bars
+// beyond what fits collapse to `grid-auto-rows: 0`, so a partial line can never
+// render regardless of the card's height. `aria-hidden` — purely decorative.
+const SHIMMER_LINE_COUNT = 28; // enough to fill the tallest (narrow-mobile) card
 
 // Reuse the ShimmerCard idiom — `bg-gray-400 rounded opacity-30` bars — so the
 // AI skeleton reads as the same visual family. The pulse lives on the Card
@@ -77,9 +85,9 @@ export function AiAnalysisShimmer({
         className={cn(
           "glassmorphic min-w-[220px] animate-pulse motion-reduce:animate-none",
           // Only the generating skeleton follows the idle state, so only it
-          // carries the no-shrink floor; the neutral Suspense fallback stays
+          // carries the no-shrink height; the neutral Suspense fallback stays
           // compact and grows into idle.
-          isGenerating && AI_CARD_MIN_H,
+          isGenerating && AI_SHIMMER_H,
           className,
         )}
       >
@@ -106,13 +114,17 @@ export function AiAnalysisShimmer({
               <Bar className="h-12 w-12 rounded-full" />
             </div>
             {isGenerating ? (
-              // Fill the reserved height with line bars so the skeleton is as
-              // large as the idle text (no void below the lines).
+              // Fill the reserved height with WHOLE line bars (auto-fill rows +
+              // collapsed overflow) so the skeleton is as large as the idle text
+              // with no void and no clipped half-line.
               <div
                 aria-hidden="true"
-                className="flex-1 self-stretch"
-                style={{ backgroundImage: LINE_FILL }}
-              />
+                className="grid min-h-0 flex-1 content-start gap-3 self-stretch overflow-hidden [grid-auto-rows:0] [grid-template-rows:repeat(auto-fill,1rem)]"
+              >
+                {Array.from({ length: SHIMMER_LINE_COUNT }).map((_, i) => (
+                  <div key={i} className="rounded bg-gray-400 opacity-30" />
+                ))}
+              </div>
             ) : (
               // Compact body — the neutral fallback stays small and grows into
               // the idle state it resolves to.

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -5,6 +5,7 @@ import {
   CardHeader,
 } from "@/components/ui/card";
 import { BrainCircuit } from "lucide-react";
+import { ActionButton } from "@/components/ui/action-button";
 import { cn } from "@/lib/utils/utils";
 
 interface AiAnalysisShimmerProps {
@@ -143,12 +144,14 @@ export function AiAnalysisShimmer({
           {/* Footer — pulsing "Generating analysis…" indicator (mirrors the
               streaming footer) or a neutral button-shaped shimmer bar. */}
           {isGenerating ? (
-            <div
-              aria-hidden="true"
-              className="flex items-center justify-end gap-2 text-sm text-muted-foreground"
-            >
-              <BrainCircuit className="size-4" />
-              <span>Generating analysis…</span>
+            // Same muted, animated CTA as the streaming card so the
+            // "Generating analysis…" affordance is identical through
+            // loading → streaming → (active) Regenerate.
+            <div className="flex justify-end" aria-hidden="true">
+              <ActionButton loading>
+                Generating analysis…
+                <BrainCircuit className="size-5 animate-pulse motion-reduce:animate-none" />
+              </ActionButton>
             </div>
           ) : (
             <div className="flex justify-end">

--- a/components/crypto/ai-analysis-shimmer.tsx
+++ b/components/crypto/ai-analysis-shimmer.tsx
@@ -22,6 +22,17 @@ interface AiAnalysisShimmerProps {
   className?: string;
 }
 
+// Shared minimum footprint so the AI card only ever GROWS across
+// idle → loading → streaming, never shrinks (NEU-23 feedback). The idle/empty
+// state is the tallest of the lightweight states, and it grows taller as the
+// viewport narrows (more text wrapping), so the floor is sized per breakpoint to
+// the measured idle height: ~670px @320 · ~554px @360 · ~502px @640 · ~398px
+// @≥1024. Applied to the states that FOLLOW idle — the "generating" skeleton and
+// the streaming/complete card — but not to idle itself or the neutral Suspense
+// fallback (which precede idle and should grow into it). If the idle copy in
+// `ai-analysis-card.tsx` changes materially, re-measure and update these.
+export const AI_CARD_MIN_H = "min-h-[680px] sm:min-h-[510px] lg:min-h-[400px]";
+
 // Reuse the ShimmerCard idiom — `bg-gray-400 rounded opacity-30` bars — so the
 // AI skeleton reads as the same visual family. The pulse lives on the Card
 // wrapper (as in ShimmerCard) and is suppressed under `prefers-reduced-motion`.
@@ -57,6 +68,10 @@ export function AiAnalysisShimmer({
       <Card
         className={cn(
           "glassmorphic min-w-[220px] animate-pulse motion-reduce:animate-none",
+          // Only the generating skeleton follows the idle state, so only it
+          // carries the no-shrink floor; the neutral Suspense fallback stays
+          // compact and grows into idle.
+          isGenerating && AI_CARD_MIN_H,
           className,
         )}
       >

--- a/components/ui/action-button.tsx
+++ b/components/ui/action-button.tsx
@@ -4,12 +4,26 @@ import { cn } from "@/lib/utils/utils";
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode;
+  /**
+   * Render a muted, non-interactive "working" state: the button is dimmed and
+   * disabled while a continuous shine sweeps across it. Used for the AI card's
+   * "Generating analysis…" affordance so the same button morphs into the active
+   * CTA when the work finishes.
+   */
+  loading?: boolean;
 };
 
-export function ActionButton({ children, className, ...rest }: Props) {
+export function ActionButton({
+  children,
+  className,
+  loading = false,
+  disabled,
+  ...rest
+}: Props) {
   return (
     <Button
       {...rest}
+      disabled={disabled || loading}
       className={cn(
         // Layout & positioning
         "relative inline-flex items-center justify-center overflow-hidden",
@@ -26,20 +40,28 @@ export function ActionButton({ children, className, ...rest }: Props) {
         "text-orange-50/100",
         // Shadows
         "shadow-md",
-        // Interactive states
-        "hover:bg-stone-800/100 hover:ring-stone-600/50 hover:shadow-lg hover:border-orange-50/100 hover:scale-104",
-        "hover:border-outset hover:border-1 hover:border-[var(--tw-glow-color)]",
-        "active:border-inset active:border-1 active:ring-0 active:bg-stone-900/70",
-        "focus-visible:outline-none",
         // Transitions & transforms
         "transition-all duration-300",
         "translate-z-3 transform-gpu",
-        // Cursor
-        "cursor-pointer",
-        className
+        loading
+          ? // Muted, non-interactive while generating.
+            "cursor-default opacity-60 saturate-50"
+          : // Interactive states
+            cn(
+              "cursor-pointer",
+              "hover:bg-stone-800/100 hover:ring-stone-600/50 hover:shadow-lg hover:border-orange-50/100 hover:scale-104",
+              "hover:border-outset hover:border-1 hover:border-[var(--tw-glow-color)]",
+              "active:border-inset active:border-1 active:ring-0 active:bg-stone-900/70",
+              "focus-visible:outline-none",
+            ),
+        className,
       )}
     >
-      <span className={cn("text-sm sm:text-base md:text-lg relative z-10 transition flex items-center gap-2 sm:gap-3")}>
+      <span
+        className={cn(
+          "text-sm sm:text-base md:text-lg relative z-10 transition flex items-center gap-2 sm:gap-3",
+        )}
+      >
         {children}
       </span>
       <span
@@ -52,10 +74,14 @@ export function ActionButton({ children, className, ...rest }: Props) {
           "skew-x-[-20deg] -translate-x-[120%]",
           // Initial state
           "opacity-0",
-          // Hover state
-          "group-hover:translate-x-[360%] group-hover:opacity-100",
-          // Transition
-          "transition duration-300 ease-out"
+          loading
+            ? // Continuous sweep while generating (suppressed for reduced motion).
+              "animate-[shimmerSweep_1.8s_ease-in-out_infinite] motion-reduce:animate-none"
+            : // Hover sweep
+              cn(
+                "group-hover:translate-x-[360%] group-hover:opacity-100",
+                "transition duration-300 ease-out",
+              ),
         )}
       />
     </Button>


### PR DESCRIPTION
## Summary

Implements task **NEU-23**: Redesign the AI analysis loading skeleton.

**Type:** feat
**Complexity:** M

The AI analysis slot reused the generic crypto `ShimmerCard` (text bars + dot + price sparkline) as its loading placeholder — a skeleton shaped for a crypto data card, not an AI text card. This replaces it with a dedicated `AiAnalysisShimmer` whose silhouette mirrors the AI card, so the loading → content handoff has no structural jump.

## What was done (core)

- Added `components/crypto/ai-analysis-shimmer.tsx` — a dedicated AI skeleton mirroring the streaming card (glassmorphic card → header title/subtitle/Beta placeholders → 12×12 avatar bubble beside a multi-line text body). RSC-safe, reduced-motion aware, no price sparkline.
- Swapped both skeleton call sites: the card's in-component `loading` state and the page's `AiAnalysisCard` Suspense fallback. The three non-AI Suspense slots keep `ShimmerCard`.
- Tests for the new skeleton; updated the card's loading test.

## Scope evolution (review feedback — visual/UX polish)

This PR grew well beyond the original "swap the skeleton" scope through iterative design review. Captured here for transparency:

1. **No-shrink layout** (`6569de0`) — the AI card now only ever grows across idle → loading → streaming, never shrinks. Per-breakpoint min-height floor (`AI_CARD_MIN_H`) sized to the measured idle height, applied only to the states that follow idle.
2. **Skeleton fills the card** (`08a4850`, `4e863cf`) — the loading skeleton now fills its reserved height with whole text-line bars (CSS grid `auto-fill`, no clipped half-lines) instead of leaving a void; the generating shimmer uses a fixed height so `auto-fill` resolves.
3. **Stable footer** (`4e863cf`) — the "Generating analysis…" indicator is pinned to the bottom so it doesn't jump from loading to streaming.
4. **Bottom padding** (`65c6411`) — `min-h-0` + `overflow-hidden` down the flex chain so the fill clips inside the fixed-height card and keeps its `py-6` gutter (was overflowing past the card edge).
5. **Smooth reveal** (`aec7e0c`) — eliminated the regenerate-button reveal overshoot/dip and the hover clipping.
6. **Unified, single CTA** (`359a979`, `4188ec2`) — the separate "Generating analysis…" text indicator and the Regenerate button are now **one** button: a muted, disabled "Generating analysis…" with a continuous shine sweep that morphs into the active "Regenerate Analysis" CTA on completion (same element, same position, fixed height → no streaming→complete layout shift). Added a `loading` variant to the shared `ActionButton`.
7. **Animated icon** (`0a15349`) — the generating icon does an eased, breathing rotate (`iconThinking` keyframe: 360° ease-in-out + scale to 1.18 at the half-turn), suppressed under reduced motion.
8. **Stable button width** (`a94aa46`) — both labels share one grid cell and cross-fade, so the CTA width stays constant across the morph (no snap), responsive with no hardcoded width.

## Verification

- `pnpm preflight` exits 0 (typecheck + eslint `--max-warnings=0` + Jest).
- The skeleton and the full idle → loading → streaming → complete flow were verified in-browser at desktop and mobile widths.

## Done When

- `pnpm preflight` exits 0.
- The card test suite asserts the `loading` branch renders `AiAnalysisShimmer`, not `ShimmerCard`.
- `AiAnalysisShimmer` is rendered by both call sites; no `LoadingSparkline` in the AI skeleton; the generic `ShimmerCard` is unchanged.

Closes NEU-23.
