### PR TITLE
feat(NEU-787): Externalize the analyst system prompt + configurable timeout

### DIFF
--- a/src/adapters/openai/OpenAiAnalysisAdapter.ts
+++ b/src/adapters/openai/OpenAiAnalysisAdapter.ts
@@ -224,9 +224,12 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
    * @returns The AI-generated analysis.
    */
   async analyzeAsset(symbol: string): Promise<string> {
-    const signal = AbortSignal.timeout(this.timeoutMs);
+    let signal: AbortSignal | undefined;
     try {
       const prompt = await this.buildPrompt(symbol);
+      // Start the timeout only for the model call — prompt-building has its own
+      // per-source timeouts and must not consume the model-call budget.
+      signal = AbortSignal.timeout(this.timeoutMs);
       const { text } = await generateText({
         model: this.model,
         system: ANALYST_SYSTEM_PROMPT,
@@ -238,7 +241,9 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
     } catch (error) {
       logError(error, { adapter: 'OpenAiAnalysisAdapter', method: 'analyzeAsset', symbol });
       // The timeout signal is the only abort source, so `aborted` means we hit it.
-      if (signal.aborted) throw this.timeoutException(symbol);
+      // It only exists once the model call has started, so a buildPrompt error
+      // is never misclassified as a timeout.
+      if (signal?.aborted) throw this.timeoutException(symbol);
       throw this.toExternalException(error, symbol);
     }
   }
@@ -250,9 +255,12 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
    * @returns An async iterable of string chunks.
    */
   async *analyzeAssetStream(symbol: string): AsyncIterable<string> {
-    const signal = AbortSignal.timeout(this.timeoutMs);
+    let signal: AbortSignal | undefined;
     try {
       const prompt = await this.buildPrompt(symbol);
+      // Start the timeout only for the model call — prompt-building has its own
+      // per-source timeouts and must not consume the model-call budget.
+      signal = AbortSignal.timeout(this.timeoutMs);
       const result = streamText({
         model: this.model,
         system: ANALYST_SYSTEM_PROMPT,
@@ -266,7 +274,9 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
     } catch (error) {
       logError(error, { adapter: 'OpenAiAnalysisAdapter', method: 'analyzeAssetStream', symbol });
       // The timeout signal is the only abort source, so `aborted` means we hit it.
-      if (signal.aborted) throw this.timeoutException(symbol);
+      // It only exists once the model call has started, so a buildPrompt error
+      // is never misclassified as a timeout.
+      if (signal?.aborted) throw this.timeoutException(symbol);
       throw this.toExternalException(error, symbol);
     }
   }

--- a/src/adapters/openai/OpenAiAnalysisAdapter.ts
+++ b/src/adapters/openai/OpenAiAnalysisAdapter.ts
@@ -5,7 +5,8 @@ import { getEnv } from "@/lib/env";
 import { logRequest, logError } from "@/lib/observability";
 import { ExternalException } from "@/lib/errors";
 import { toBinancePair } from "@/lib/symbolMeta";
-import { AI_LLM_MODEL, AI_LLM_REASONING_EFFORT, AI_NEWS_LIMIT, AI_PRICE_HISTORY_DAYS } from "@/lib/config";
+import { AI_LLM_MODEL, AI_LLM_REASONING_EFFORT, AI_LLM_TIMEOUT_MS, AI_NEWS_LIMIT, AI_PRICE_HISTORY_DAYS } from "@/lib/config";
+import { ANALYST_SYSTEM_PROMPT } from "@/adapters/openai/prompts/analystPrompt";
 import { BinancePort, Candlestick } from "@/ports/BinancePort";
 import { NewsPort } from "@/ports/NewsPort";
 import { NewsArticle } from "@/domain/newsArticle";
@@ -17,27 +18,21 @@ const PROVIDER_OPTIONS = {
   openai: { reasoningEffort: AI_LLM_REASONING_EFFORT },
 } as const;
 
-const SYSTEM_PROMPT = `You are a cryptocurrency market analyst providing concise, actionable insights.
-
-Your role:
-- Analyze price data, VWAP, and news sentiment
-- Provide short-term bias (bullish/bearish/sideways)
-- Identify key signals (trend, momentum, volatility)
-- Keep analysis brief and focused (3-4 paragraphs max)
-
-Format your response with:
-1. **Market Bias**: Current short-term direction
-2. **Price Analysis**: Key levels and VWAP context
-3. **News Sentiment**: Recent developments impact
-4. **Key Takeaway**: One clear actionable insight
-
-Do not provide financial advice. Focus on data-driven observations.`;
-
 /**
  * Returns the rejection reason of a settled result as a short message.
  */
 function settledError(result: PromiseRejectedResult): string {
   return result.reason instanceof Error ? result.reason.message : String(result.reason);
+}
+
+/**
+ * Resolves the model-call timeout: the AI_ANALYSIS_TIMEOUT_MS env value when it
+ * is a positive integer, otherwise the AI_LLM_TIMEOUT_MS default.
+ * Exported for unit testing of the parse/guard logic.
+ */
+export function resolveTimeoutMs(raw: string | undefined): number {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : AI_LLM_TIMEOUT_MS;
 }
 
 /**
@@ -137,6 +132,7 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
   private model: LanguageModel;
   private binance: BinancePort;
   private news: NewsPort;
+  private timeoutMs: number;
 
   constructor(deps: { binance: BinancePort; news: NewsPort }) {
     const env = getEnv();
@@ -151,8 +147,20 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
     const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
     // Treat a blank OPENAI_MODEL as unset — `??` would not fall back on "".
     this.model = openai(env.OPENAI_MODEL?.trim() || AI_LLM_MODEL);
+    this.timeoutMs = resolveTimeoutMs(env.AI_ANALYSIS_TIMEOUT_MS);
     this.binance = deps.binance;
     this.news = deps.news;
+  }
+
+  /**
+   * Builds an ExternalException(Timeout) for a model call aborted by our
+   * timeout signal.
+   */
+  private timeoutException(symbol: string): ExternalException {
+    return new ExternalException(
+      { kind: 'Timeout', timeoutMs: this.timeoutMs, details: { symbol } },
+      `Analysis of ${symbol} timed out after ${this.timeoutMs}ms`,
+    );
   }
 
   /**
@@ -216,17 +224,21 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
    * @returns The AI-generated analysis.
    */
   async analyzeAsset(symbol: string): Promise<string> {
+    const signal = AbortSignal.timeout(this.timeoutMs);
     try {
       const prompt = await this.buildPrompt(symbol);
       const { text } = await generateText({
         model: this.model,
-        system: SYSTEM_PROMPT,
+        system: ANALYST_SYSTEM_PROMPT,
         prompt,
         providerOptions: PROVIDER_OPTIONS,
+        abortSignal: signal,
       });
       return text;
     } catch (error) {
       logError(error, { adapter: 'OpenAiAnalysisAdapter', method: 'analyzeAsset', symbol });
+      // The timeout signal is the only abort source, so `aborted` means we hit it.
+      if (signal.aborted) throw this.timeoutException(symbol);
       throw this.toExternalException(error, symbol);
     }
   }
@@ -238,19 +250,23 @@ export class OpenAiAnalysisAdapter implements AiAnalysisPort {
    * @returns An async iterable of string chunks.
    */
   async *analyzeAssetStream(symbol: string): AsyncIterable<string> {
+    const signal = AbortSignal.timeout(this.timeoutMs);
     try {
       const prompt = await this.buildPrompt(symbol);
       const result = streamText({
         model: this.model,
-        system: SYSTEM_PROMPT,
+        system: ANALYST_SYSTEM_PROMPT,
         prompt,
         providerOptions: PROVIDER_OPTIONS,
+        abortSignal: signal,
       });
       for await (const chunk of result.textStream) {
         yield chunk;
       }
     } catch (error) {
       logError(error, { adapter: 'OpenAiAnalysisAdapter', method: 'analyzeAssetStream', symbol });
+      // The timeout signal is the only abort source, so `aborted` means we hit it.
+      if (signal.aborted) throw this.timeoutException(symbol);
       throw this.toExternalException(error, symbol);
     }
   }

--- a/src/adapters/openai/__tests__/OpenAiAnalysisAdapter.test.ts
+++ b/src/adapters/openai/__tests__/OpenAiAnalysisAdapter.test.ts
@@ -293,6 +293,42 @@ describe('OpenAiAnalysisAdapter', () => {
         timeoutMs: 20,
       });
     });
+
+    it('does not classify an analyzeAsset buildPrompt failure as Timeout (signal not yet created)', async () => {
+      process.env.AI_ANALYSIS_TIMEOUT_MS = '20';
+      deps.binance.getDailyCandles.mockImplementation(() => {
+        throw new Error('build boom');
+      });
+      mockGenerateText.mockResolvedValue({ text: 'unused' });
+
+      await expect(freshAdapter().analyzeAsset('BTC')).rejects.toMatchObject({
+        name: 'ExternalException',
+        kind: 'Unavailable',
+      });
+      expect(mockGenerateText).not.toHaveBeenCalled();
+    });
+
+    it('does not classify an analyzeAssetStream buildPrompt failure as Timeout (signal not yet created)', async () => {
+      process.env.AI_ANALYSIS_TIMEOUT_MS = '20';
+      deps.binance.getDailyCandles.mockImplementation(() => {
+        throw new Error('build boom');
+      });
+      mockStreamText.mockReturnValue({ textStream: gen(['unused']) });
+
+      const run = async () => {
+        const out: string[] = [];
+        for await (const chunk of freshAdapter().analyzeAssetStream('BTC')) {
+          out.push(chunk);
+        }
+        return out;
+      };
+
+      await expect(run()).rejects.toMatchObject({
+        name: 'ExternalException',
+        kind: 'Unavailable',
+      });
+      expect(mockStreamText).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/adapters/openai/__tests__/OpenAiAnalysisAdapter.test.ts
+++ b/src/adapters/openai/__tests__/OpenAiAnalysisAdapter.test.ts
@@ -15,7 +15,7 @@ jest.mock('@ai-sdk/openai', () => ({
   createOpenAI: (...args: unknown[]) => (mockCreateOpenAI as jest.Mock)(...args),
 }));
 
-import { OpenAiAnalysisAdapter } from '../OpenAiAnalysisAdapter';
+import { OpenAiAnalysisAdapter, resolveTimeoutMs } from '../OpenAiAnalysisAdapter';
 import { ExternalException } from '@/lib/errors';
 import type { Candlestick } from '@/ports/BinancePort';
 import type { NewsArticle } from '@/domain/newsArticle';
@@ -71,6 +71,10 @@ describe('OpenAiAnalysisAdapter', () => {
     mockCreateOpenAI.mockImplementation(() => mockProvider);
     process.env = { ...ORIGINAL_ENV, OPENAI_API_KEY: 'test-key' };
     delete process.env.OPENAI_MODEL;
+    // Keep the per-call AbortSignal.timeout short so its timer doesn't outlive
+    // the (fast, immediately-resolving) test and leak into Jest teardown.
+    // The timeout tests below override this with their own tiny value.
+    process.env.AI_ANALYSIS_TIMEOUT_MS = '100';
     deps = makeDeps();
   });
 
@@ -225,5 +229,90 @@ describe('OpenAiAnalysisAdapter', () => {
         kind: 'Unavailable',
       });
     });
+  });
+
+  describe('timeout', () => {
+    beforeEach(() => {
+      deps.binance.getDailyCandles.mockResolvedValue([candle(100)]);
+      deps.binance.get24HrStats.mockResolvedValue(100);
+      deps.news.fetchNews.mockResolvedValue([]);
+    });
+
+    it('passes an AbortSignal to generateText and streamText', async () => {
+      mockGenerateText.mockResolvedValue({ text: 'ok' });
+      mockStreamText.mockReturnValue({ textStream: gen(['ok']) });
+
+      await freshAdapter().analyzeAsset('BTC');
+      expect(mockGenerateText.mock.calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
+
+      const streamed: string[] = [];
+      for await (const chunk of freshAdapter().analyzeAssetStream('BTC')) {
+        streamed.push(chunk);
+      }
+      expect(streamed).toEqual(['ok']);
+      expect(mockStreamText.mock.calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('maps an analyzeAsset timeout to ExternalException(Timeout)', async () => {
+      process.env.AI_ANALYSIS_TIMEOUT_MS = '20';
+      mockGenerateText.mockImplementation(({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          abortSignal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        }),
+      );
+
+      await expect(freshAdapter().analyzeAsset('BTC')).rejects.toMatchObject({
+        name: 'ExternalException',
+        kind: 'Timeout',
+        timeoutMs: 20,
+      });
+    });
+
+    it('maps an analyzeAssetStream timeout to ExternalException(Timeout)', async () => {
+      process.env.AI_ANALYSIS_TIMEOUT_MS = '20';
+      mockStreamText.mockImplementation(({ abortSignal }: { abortSignal: AbortSignal }) => ({
+        textStream: (async function* () {
+          await new Promise<never>((_resolve, reject) => {
+            abortSignal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          });
+          yield 'never';
+        })(),
+      }));
+
+      const run = async () => {
+        const out: string[] = [];
+        for await (const chunk of freshAdapter().analyzeAssetStream('BTC')) {
+          out.push(chunk);
+        }
+        return out;
+      };
+
+      await expect(run()).rejects.toMatchObject({
+        name: 'ExternalException',
+        kind: 'Timeout',
+        timeoutMs: 20,
+      });
+    });
+  });
+});
+
+describe('resolveTimeoutMs', () => {
+  const DEFAULT = 30_000;
+
+  it('accepts a positive integer string', () => {
+    expect(resolveTimeoutMs('5000')).toBe(5000);
+  });
+
+  it('falls back to the default for unset/blank/whitespace', () => {
+    expect(resolveTimeoutMs(undefined)).toBe(DEFAULT);
+    expect(resolveTimeoutMs('')).toBe(DEFAULT);
+    expect(resolveTimeoutMs('   ')).toBe(DEFAULT);
+  });
+
+  it('falls back to the default for non-positive, non-integer, or non-numeric values', () => {
+    expect(resolveTimeoutMs('0')).toBe(DEFAULT);
+    expect(resolveTimeoutMs('-5')).toBe(DEFAULT);
+    expect(resolveTimeoutMs('30.5')).toBe(DEFAULT);
+    expect(resolveTimeoutMs('abc')).toBe(DEFAULT);
   });
 });

--- a/src/adapters/openai/prompts/__tests__/analystPrompt.test.ts
+++ b/src/adapters/openai/prompts/__tests__/analystPrompt.test.ts
@@ -1,0 +1,18 @@
+import { ANALYST_SYSTEM_PROMPT } from '../analystPrompt';
+
+describe('ANALYST_SYSTEM_PROMPT', () => {
+  it('defines the analyst role', () => {
+    expect(ANALYST_SYSTEM_PROMPT).toContain('cryptocurrency market analyst');
+  });
+
+  it('lists the four response sections', () => {
+    expect(ANALYST_SYSTEM_PROMPT).toContain('**Market Bias**');
+    expect(ANALYST_SYSTEM_PROMPT).toContain('**Price Analysis**');
+    expect(ANALYST_SYSTEM_PROMPT).toContain('**News Sentiment**');
+    expect(ANALYST_SYSTEM_PROMPT).toContain('**Key Takeaway**');
+  });
+
+  it('keeps the no-financial-advice guardrail', () => {
+    expect(ANALYST_SYSTEM_PROMPT).toContain('Do not provide financial advice');
+  });
+});

--- a/src/adapters/openai/prompts/analystPrompt.ts
+++ b/src/adapters/openai/prompts/analystPrompt.ts
@@ -1,0 +1,22 @@
+/**
+ * Versioned analyst system prompt for the AI analysis adapter.
+ *
+ * Kept in its own module (rather than inline in the adapter) so the prompt is
+ * independently testable and its evolution is visible in git history. Edit the
+ * wording here; the adapter imports it verbatim.
+ */
+export const ANALYST_SYSTEM_PROMPT = `You are a cryptocurrency market analyst providing concise, actionable insights.
+
+Your role:
+- Analyze price data, VWAP, and news sentiment
+- Provide short-term bias (bullish/bearish/sideways)
+- Identify key signals (trend, momentum, volatility)
+- Keep analysis brief and focused (3-4 paragraphs max)
+
+Format your response with:
+1. **Market Bias**: Current short-term direction
+2. **Price Analysis**: Key levels and VWAP context
+3. **News Sentiment**: Recent developments impact
+4. **Key Takeaway**: One clear actionable insight
+
+Do not provide financial advice. Focus on data-driven observations.`;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,3 +28,7 @@ export const AI_LLM_MODEL = "gpt-5.5";
 // GPT-5.x are reasoning models and use `reasoning_effort` instead of `temperature`.
 // "low" keeps latency close to the <10s target for these short analyses.
 export const AI_LLM_REASONING_EFFORT = "low";
+// Default request timeout for the model call. Override per-environment with the
+// AI_ANALYSIS_TIMEOUT_MS env var; the adapter falls back to this default when
+// the env var is unset or not a positive integer.
+export const AI_LLM_TIMEOUT_MS = 30_000;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -21,6 +21,10 @@ const EnvSchema = z.object({
   // When truthy, permits the gated per-browser `x-ai-analysis-mode` override
   // even in production. In non-prod the override is allowed regardless.
   AI_ANALYSIS_ALLOW_CLIENT_OVERRIDE: z.string().optional(),
+  // Request timeout (ms) for the AI analysis model call. String here; the
+  // adapter parses and positive-integer-guards it, falling back to
+  // AI_LLM_TIMEOUT_MS when unset or invalid.
+  AI_ANALYSIS_TIMEOUT_MS: z.string().optional(),
 });
 
 type Env = z.infer<typeof EnvSchema>;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,12 +1,14 @@
 export type ExternalError =
   | { kind: 'RateLimited'; retryAfterSec?: number; details?: unknown }
   | { kind: 'Unavailable'; details?: unknown }
-  | { kind: 'InvalidRequest'; details?: unknown };
+  | { kind: 'InvalidRequest'; details?: unknown }
+  | { kind: 'Timeout'; timeoutMs?: number; details?: unknown };
 
 export class ExternalException extends Error {
   readonly kind: ExternalError['kind'];
   readonly details?: unknown;
   readonly retryAfterSec?: number;
+  readonly timeoutMs?: number;
 
   constructor(error: ExternalError, message?: string) {
     super(message ?? error.kind);
@@ -16,6 +18,9 @@ export class ExternalException extends Error {
     this.details = error.details;
     if (error.kind === 'RateLimited') {
       this.retryAfterSec = error.retryAfterSec;
+    }
+    if (error.kind === 'Timeout') {
+      this.timeoutMs = error.timeoutMs;
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements task **NEU-787**: Externalize the analyst system prompt + configurable timeout.

**Type:** feat
**Complexity:** M

## What was done

- Moved the inline analyst system prompt into a versioned, unit-tested module `src/adapters/openai/prompts/analystPrompt.ts` (`ANALYST_SYSTEM_PROMPT`); the adapter now imports it and holds no inline prompt string.
- Added a configurable model-call timeout: `AI_LLM_TIMEOUT_MS` default (30s) in `config.ts`, overridable via the `AI_ANALYSIS_TIMEOUT_MS` env var (positive-integer guard, else fallback). Both `analyzeAsset` and `analyzeAssetStream` now pass `AbortSignal.timeout(...)`.
- Added a typed `Timeout` variant to the `ExternalError` union; a timed-out call throws `ExternalException(kind: 'Timeout', timeoutMs)`. Non-timeout errors still map to `Unavailable`, and existing `ExternalException`s pass through unchanged.
- Tests: prompt contract + `abortSignal` wiring + timeout→`Timeout` for both methods + `resolveTimeoutMs` parse/guard matrix.

## Done When

- `ANALYST_SYSTEM_PROMPT` lives in `prompts/analystPrompt.ts`; the adapter contains no inline prompt string.
- Both model calls pass `abortSignal`, and an aborted call throws `ExternalException` with `kind === 'Timeout'`.
- `pnpm preflight` exits 0.

## Follow-up (out of scope)

- `src/lib/http/apiErrorResponse.ts` maps the new `Timeout` kind to 502; consider mapping it to 504 and surfacing `timeoutMs`. Left out per the spec's API-surfacing exclusion.
