### PR TITLE
feat(NEU-25): Implement Complete State with Reveal Animation

### DIFF
--- a/components/crypto/__tests__/ai-analysis-card.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-card.test.tsx
@@ -290,6 +290,20 @@ describe("AiAnalysisCard", () => {
   });
 
   describe("copy-to-clipboard", () => {
+    // Capture the original `navigator.clipboard` descriptor so each test's mock
+    // is reverted afterwards and never leaks into other tests.
+    const originalClipboard = Object.getOwnPropertyDescriptor(
+      navigator,
+      "clipboard",
+    );
+    afterEach(() => {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        Reflect.deleteProperty(navigator, "clipboard");
+      }
+    });
+
     /** Install a controllable `navigator.clipboard.writeText` mock. */
     function mockClipboard(impl: () => Promise<void>) {
       const writeText = jest.fn(impl);
@@ -309,7 +323,7 @@ describe("AiAnalysisCard", () => {
       );
 
       fireEvent.click(
-        screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+        screen.getByRole("button", { name: "Copy" }),
       );
 
       expect(writeText).toHaveBeenCalledWith("## Bias\nBullish momentum.");
@@ -328,7 +342,7 @@ describe("AiAnalysisCard", () => {
         setHook({ isLoading: false, completion: "Done." }, { finish: true });
 
         fireEvent.click(
-          screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+          screen.getByRole("button", { name: "Copy" }),
         );
         // Flush the writeText microtask so `copied` flips to true.
         await act(async () => {
@@ -351,7 +365,7 @@ describe("AiAnalysisCard", () => {
       setHook({ isLoading: false, completion: "Done." }, { finish: true });
 
       fireEvent.click(
-        screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+        screen.getByRole("button", { name: "Copy" }),
       );
       await act(async () => {
         await Promise.resolve();
@@ -369,7 +383,7 @@ describe("AiAnalysisCard", () => {
       setHook({ isLoading: false, completion: "Done." }, { finish: true });
 
       const button = screen.getByRole("button", {
-        name: /copy analysis to clipboard/i,
+        name: "Copy",
       });
       expect(() => fireEvent.click(button)).not.toThrow();
       expect(screen.queryByText("Copied")).not.toBeInTheDocument();
@@ -380,12 +394,12 @@ describe("AiAnalysisCard", () => {
 
       setHook({ isLoading: true, completion: "Streaming…" });
       expect(
-        screen.queryByRole("button", { name: /copy analysis to clipboard/i }),
+        screen.queryByRole("button", { name: "Copy" }),
       ).not.toBeInTheDocument();
 
       setHook({ isLoading: false, completion: "" }, { finish: true });
       expect(
-        screen.queryByRole("button", { name: /copy analysis to clipboard/i }),
+        screen.queryByRole("button", { name: "Copy" }),
       ).not.toBeInTheDocument();
     });
   });

--- a/components/crypto/__tests__/ai-analysis-card.test.tsx
+++ b/components/crypto/__tests__/ai-analysis-card.test.tsx
@@ -288,4 +288,118 @@ describe("AiAnalysisCard", () => {
 
     expect(mockStop).toHaveBeenCalled();
   });
+
+  describe("copy-to-clipboard", () => {
+    /** Install a controllable `navigator.clipboard.writeText` mock. */
+    function mockClipboard(impl: () => Promise<void>) {
+      const writeText = jest.fn(impl);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+      return writeText;
+    }
+
+    it("copies the raw markdown analysis and shows a confirmation", async () => {
+      const writeText = mockClipboard(() => Promise.resolve());
+      render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+      setHook(
+        { isLoading: false, completion: "## Bias\nBullish momentum." },
+        { finish: true },
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+      );
+
+      expect(writeText).toHaveBeenCalledWith("## Bias\nBullish momentum.");
+      // The confirmation appears once the async write resolves.
+      expect(await screen.findByText("Copied")).toBeInTheDocument();
+      expect(
+        screen.getByText("Analysis copied to clipboard."),
+      ).toBeInTheDocument();
+    });
+
+    it("reverts the confirmation after the timeout", async () => {
+      jest.useFakeTimers();
+      try {
+        mockClipboard(() => Promise.resolve());
+        render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+        setHook({ isLoading: false, completion: "Done." }, { finish: true });
+
+        fireEvent.click(
+          screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+        );
+        // Flush the writeText microtask so `copied` flips to true.
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(screen.getByText("Copied")).toBeInTheDocument();
+
+        act(() => {
+          jest.advanceTimersByTime(2000);
+        });
+        expect(screen.getByText("Copy")).toBeInTheDocument();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("does not confirm when the clipboard write is rejected", async () => {
+      mockClipboard(() => Promise.reject(new Error("denied")));
+      render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+      setHook({ isLoading: false, completion: "Done." }, { finish: true });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /copy analysis to clipboard/i }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("Copied")).not.toBeInTheDocument();
+    });
+
+    it("is a no-op when the clipboard API is unavailable", () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        configurable: true,
+      });
+      render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+      setHook({ isLoading: false, completion: "Done." }, { finish: true });
+
+      const button = screen.getByRole("button", {
+        name: /copy analysis to clipboard/i,
+      });
+      expect(() => fireEvent.click(button)).not.toThrow();
+      expect(screen.queryByText("Copied")).not.toBeInTheDocument();
+    });
+
+    it("omits the copy button while streaming and for an empty completed stream", () => {
+      render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+
+      setHook({ isLoading: true, completion: "Streaming…" });
+      expect(
+        screen.queryByRole("button", { name: /copy analysis to clipboard/i }),
+      ).not.toBeInTheDocument();
+
+      setHook({ isLoading: false, completion: "" }, { finish: true });
+      expect(
+        screen.queryByRole("button", { name: /copy analysis to clipboard/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a completion timestamp on complete but not while streaming", () => {
+    render(<AiAnalysisCard name="Bitcoin" symbol="BTC" />);
+
+    setHook({ isLoading: true, completion: "Partial analysis" });
+    expect(screen.queryByText(/generated at/i)).not.toBeInTheDocument();
+
+    setHook(
+      { isLoading: false, completion: "Partial analysis done." },
+      { finish: true },
+    );
+    expect(screen.getByText(/generated at/i)).toBeInTheDocument();
+  });
 });

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -220,25 +220,28 @@ function CopyButton({ text }: { text: string }) {
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label="Copy analysis to clipboard"
-      className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors cursor-pointer hover:bg-muted/40 hover:text-foreground"
-    >
-      {copied ? (
-        <Check aria-hidden="true" className="size-4" />
-      ) : (
-        <Copy aria-hidden="true" className="size-4" />
-      )}
-      {copied ? "Copied" : "Copy"}
-      {/* Polite announcement of the copy, separate from the card-level
-          "Analysis ready." status. No `role="status"` here — that would add a
-          second status region; `aria-live` alone announces the change. */}
+    <>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors cursor-pointer hover:bg-muted/40 hover:text-foreground"
+      >
+        {copied ? (
+          <Check aria-hidden="true" className="size-4" />
+        ) : (
+          <Copy aria-hidden="true" className="size-4" />
+        )}
+        {copied ? "Copied" : "Copy"}
+      </button>
+      {/* Polite announcement of the copy result. Kept OUTSIDE the button so the
+          button's accessible name stays equal to its visible label ("Copy" /
+          "Copied", WCAG 2.5.3) rather than a stale `aria-label`. No
+          `role="status"` — that would add a second status region alongside the
+          card's "Analysis ready." one; `aria-live` alone announces the change. */}
       <span className="sr-only" aria-live="polite">
         {copied ? "Analysis copied to clipboard." : ""}
       </span>
-    </button>
+    </>
   );
 }
 

--- a/components/crypto/ai-analysis-card.tsx
+++ b/components/crypto/ai-analysis-card.tsx
@@ -9,7 +9,7 @@ import {
   CardAction,
 } from "@/components/ui/card";
 import { ActionButton } from "@/components/ui/action-button";
-import { BrainCircuit } from "lucide-react";
+import { BrainCircuit, Check, Copy } from "lucide-react";
 import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import type { Components } from "react-markdown";
 import {
@@ -187,6 +187,61 @@ function ModeToggle({
   );
 }
 
+/**
+ * Secondary control that copies the analysis to the clipboard. Deliberately a
+ * plain button — `ActionButton` stays reserved for the prominent Regenerate CTA.
+ * Shows a transient "Copied" confirmation (Check icon + label) for ~2s, with a
+ * polite live region distinct from the card's "Analysis ready." announcement.
+ */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  // Hold the reset timer so it can be cleared on unmount and before re-arming,
+  // avoiding a setState after unmount.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const handleCopy = async () => {
+    // Guard environments without the async Clipboard API (older browsers / SSR).
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Write rejected (e.g. denied permission) — fail silently, no confirmation.
+      return;
+    }
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label="Copy analysis to clipboard"
+      className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors cursor-pointer hover:bg-muted/40 hover:text-foreground"
+    >
+      {copied ? (
+        <Check aria-hidden="true" className="size-4" />
+      ) : (
+        <Copy aria-hidden="true" className="size-4" />
+      )}
+      {copied ? "Copied" : "Copy"}
+      {/* Polite announcement of the copy, separate from the card-level
+          "Analysis ready." status. No `role="status"` here — that would add a
+          second status region; `aria-live` alone announces the change. */}
+      <span className="sr-only" aria-live="polite">
+        {copied ? "Analysis copied to clipboard." : ""}
+      </span>
+    </button>
+  );
+}
+
 export function AiAnalysisCard({
   name,
   symbol,
@@ -202,6 +257,10 @@ export function AiAnalysisCard({
   // text, so an empty-but-successful response still reveals the completed card
   // (matching the pre-migration behavior) instead of silently reverting to idle.
   const [hasCompleted, setHasCompleted] = useState(false);
+  // When the current run finished, captured once on `onFinish`. Drives the
+  // complete-state timestamp; cleared on regenerate so a new run shows no time
+  // until it finishes. Set/cleared alongside `hasCompleted`.
+  const [completedAt, setCompletedAt] = useState<Date | null>(null);
   const titleId = useId();
 
   // The AI SDK hook owns the streaming lifecycle: `completion` accumulates the
@@ -212,7 +271,10 @@ export function AiAnalysisCard({
   const { completion, complete, error, isLoading, stop } = useCompletion({
     api: `/api/ai-analysis/${symbol}`,
     streamProtocol: "text",
-    onFinish: () => setHasCompleted(true),
+    onFinish: () => {
+      setHasCompleted(true);
+      setCompletedAt(new Date());
+    },
   });
 
   // Abort any in-flight stream when the component unmounts (e.g. the user
@@ -235,6 +297,7 @@ export function AiAnalysisCard({
         ? { headers: { [AI_ANALYSIS_MODE_HEADER]: requestedMode } }
         : undefined;
     setHasCompleted(false);
+    setCompletedAt(null);
     void complete("", options);
   };
 
@@ -305,7 +368,29 @@ export function AiAnalysisCard({
               analysis…" while streaming that morphs into the active Regenerate
               CTA on completion — same element, same position, fixed height, so
               there is no layout shift on the streaming → complete transition. */}
-          <div className="flex justify-end">
+          <div className="flex items-center justify-between gap-3">
+            {/* Copy + timestamp surface only in the complete state. While
+                streaming an empty spacer holds the layout so the Regenerate
+                button keeps its right-aligned position — no shift on the morph. */}
+            {isStreaming ? (
+              <span />
+            ) : (
+              <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                {/* Only offer copy when there's text — a successful stream can
+                    complete empty (reached via `hasCompleted`), and a Copy
+                    button there would confirm a copy of nothing. */}
+                {completion.length > 0 && <CopyButton text={completion} />}
+                {completedAt && (
+                  <span>
+                    Generated at{" "}
+                    {completedAt.toLocaleTimeString(undefined, {
+                      hour: "numeric",
+                      minute: "2-digit",
+                    })}
+                  </span>
+                )}
+              </div>
+            )}
             <ActionButton
               loading={isStreaming}
               onClick={handleGenerate}


### PR DESCRIPTION
## Summary

Implements task **NEU-25**: Implement Complete State with Reveal Animation

**Type:** feat
**Complexity:** S

Closes the two remaining unchecked acceptance criteria on the AI analysis card's complete state. The reveal transition, markdown rendering, Regenerate CTA, button morph, and "Analysis ready." announcement already shipped (NEU-22 / NEU-786).

## What was done

- Added a `completedAt` value captured once in the `useCompletion` `onFinish` (cleared on regenerate, alongside `hasCompleted`) and render an absolute-local-time "Generated at HH:MM" timestamp in the complete state.
- Added a `CopyButton` secondary control (plain button — `ActionButton` stays reserved for the CTA) that copies the raw markdown analysis via `navigator.clipboard.writeText`, shows a transient Check + "Copied" confirmation (~2s, timer cleaned up on unmount), guards clipboard availability, and announces the copy via a polite `aria-live` region distinct from the card's status.
- Copy + timestamp render only in the complete state; an empty spacer holds the streaming layout so the Regenerate button keeps its position — no layout shift on the streaming → complete morph. Copy is omitted for an empty-but-complete stream.
- Added 6 component tests (copy success/confirmation, ~2s revert, rejection path, unavailable-clipboard no-op, streaming/empty absence, timestamp). Full suite green; patch coverage ~100%.

## Done When

- `pnpm preflight` exits 0 (typecheck + eslint zero-warnings + all Jest tests pass).
- Tests assert copy writes `completion` to the clipboard and shows then clears the "Copied" state; a completed card renders a "Generated at …" timestamp absent during streaming.
- The complete-state action row shows a copy button and completion timestamp; neither appears while streaming, loading, idle, or in error — with no layout shift on the streaming → complete transition.
