### PR TITLE
feat(NEU-21): Global TTL cache for AI analysis (dedup + simulated cache-hit streaming)

### DIFF
--- a/src/adapters/cache/CachingAiAnalysisAdapter.ts
+++ b/src/adapters/cache/CachingAiAnalysisAdapter.ts
@@ -1,0 +1,199 @@
+import { AiAnalysisPort } from '@/ports/AiAnalysisPort';
+import type { AiAnalysisMode } from '@/lib/aiAnalysisMode';
+import {
+  AI_ANALYSIS_CACHE_MAX_ENTRIES,
+  AI_ANALYSIS_CACHE_TTL_S,
+  AI_ANALYSIS_REPLAY_MIN_CHUNK_MS,
+  AI_ANALYSIS_REPLAY_TOTAL_MS,
+} from '@/lib/config';
+import {
+  createStreamBroadcaster,
+  type StreamBroadcaster,
+} from '@/lib/http/streamBroadcaster';
+
+/**
+ * Stream-aware caching decorator over {@link AiAnalysisPort}.
+ *
+ * Wraps an inner adapter (the live OpenAI adapter or the mock) and adds three
+ * behaviors without changing the port contract — the route and use case stay
+ * unchanged:
+ *
+ * 1. **TTL cache hit** — a repeat request within {@link AI_ANALYSIS_CACHE_TTL_S}
+ *    re-emits the stored text as a *paced* stream (see {@link pacedReplay}), so
+ *    the card's `useCompletion` (`streamProtocol: "text"`) renders it as typing
+ *    just like a fresh generation. No model call is made.
+ * 2. **In-flight dedup** — concurrent requests for the same key share ONE
+ *    upstream call via a {@link StreamBroadcaster}: the first drives the model,
+ *    later callers replay the buffered prefix then subscribe to live chunks.
+ * 3. **Miss** — forward live chunks while accumulating; store the full text on
+ *    successful, non-empty completion only.
+ *
+ * State (the cache and in-flight registries) is module-level so it is shared
+ * across the per-mode memoized instances created in the composition root. The
+ * key includes mode and model id, so a mock blob is never served as live and a
+ * model bump invalidates stale entries.
+ *
+ * Store is in-memory and per-instance (team decision). The decorator interface
+ * lets a shared store (Redis/Upstash) slot in later with no route/use-case
+ * change.
+ */
+
+interface CacheEntry {
+  text: string;
+  expiresAt: number;
+}
+
+// Module-level so all per-mode adapter instances share one cache/registry.
+const cache = new Map<string, CacheEntry>();
+const inflightStreams = new Map<string, StreamBroadcaster>();
+const inflightTexts = new Map<string, Promise<string>>();
+
+const TTL_MS = AI_ANALYSIS_CACHE_TTL_S * 1000;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Reads a non-expired entry, refreshing its LRU recency. Lazy-expires on read. */
+function readFresh(key: string): string | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  // Re-insert to mark most-recently-used (Map preserves insertion order).
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.text;
+}
+
+/** Stores a successful result and evicts the least-recently-used over the cap. */
+function writeCache(key: string, text: string): void {
+  cache.delete(key);
+  cache.set(key, { text, expiresAt: Date.now() + TTL_MS });
+  while (cache.size > AI_ANALYSIS_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+/** Splits text into word-boundary chunks, preserving whitespace. */
+function toTokens(text: string): string[] {
+  return text.match(/\S+\s*/g) ?? [text];
+}
+
+/**
+ * Re-emit stored text as a paced "typed" stream. Groups tokens so the whole
+ * replay lands near {@link AI_ANALYSIS_REPLAY_TOTAL_MS}, never faster than
+ * {@link AI_ANALYSIS_REPLAY_MIN_CHUNK_MS} per chunk. If the consumer stops
+ * pulling (client disconnect), the generator suspends and replay stops.
+ */
+async function* pacedReplay(text: string): AsyncIterable<string> {
+  const tokens = toTokens(text);
+  // Cap chunk count so per-chunk delay stays at/above the floor.
+  const maxChunks = Math.max(1, Math.floor(AI_ANALYSIS_REPLAY_TOTAL_MS / AI_ANALYSIS_REPLAY_MIN_CHUNK_MS));
+  const groupSize = Math.max(1, Math.ceil(tokens.length / maxChunks));
+
+  const chunks: string[] = [];
+  for (let i = 0; i < tokens.length; i += groupSize) {
+    chunks.push(tokens.slice(i, i + groupSize).join(''));
+  }
+
+  const perChunkMs = Math.max(
+    AI_ANALYSIS_REPLAY_MIN_CHUNK_MS,
+    Math.round(AI_ANALYSIS_REPLAY_TOTAL_MS / chunks.length),
+  );
+
+  // Emit the first chunk immediately so the route's eager first-chunk pull is
+  // not stalled (a fresh stream's first token also arrives without delay);
+  // pace the gaps between subsequent chunks to mimic typing.
+  for (let i = 0; i < chunks.length; i++) {
+    if (i > 0) await delay(perChunkMs);
+    yield chunks[i];
+  }
+}
+
+/** Clears all cache and in-flight state. Test-only. */
+export function resetAiAnalysisCache(): void {
+  cache.clear();
+  inflightStreams.clear();
+  inflightTexts.clear();
+}
+
+export class CachingAiAnalysisAdapter implements AiAnalysisPort {
+  private readonly inner: AiAnalysisPort;
+  private readonly mode: AiAnalysisMode;
+  private readonly model: string;
+
+  constructor(inner: AiAnalysisPort, opts: { mode: AiAnalysisMode; model: string }) {
+    this.inner = inner;
+    this.mode = opts.mode;
+    this.model = opts.model;
+  }
+
+  /** Cache key: mode and model guard against cross-mode/stale-model bleed. */
+  private key(symbol: string): string {
+    return `${this.mode}:${this.model}:${symbol.toUpperCase()}`;
+  }
+
+  async analyzeAsset(symbol: string): Promise<string> {
+    const key = this.key(symbol);
+
+    const cached = readFresh(key);
+    if (cached !== undefined) return cached;
+
+    const existing = inflightTexts.get(key);
+    if (existing) return existing;
+
+    const promise = this.inner.analyzeAsset(symbol).then((text) => {
+      if (text.trim().length > 0) writeCache(key, text);
+      return text;
+    });
+    inflightTexts.set(key, promise);
+    const cleanup = () => {
+      if (inflightTexts.get(key) === promise) inflightTexts.delete(key);
+    };
+    // Both handlers provided, so a rejection here is handled (no unhandled
+    // rejection); the original promise is returned to the caller to await.
+    promise.then(cleanup, cleanup);
+
+    return promise;
+  }
+
+  async *analyzeAssetStream(symbol: string): AsyncIterable<string> {
+    const key = this.key(symbol);
+
+    const cached = readFresh(key);
+    if (cached !== undefined) {
+      yield* pacedReplay(cached);
+      return;
+    }
+
+    // Join an in-flight computation if one exists and is still joinable.
+    // subscribe() returns null for a canceled broadcaster (its source was
+    // stopped when the last consumer left) — in that case fall through and
+    // start a fresh upstream call.
+    const existing = inflightStreams.get(key)?.subscribe();
+    if (existing) {
+      yield* existing;
+      return;
+    }
+
+    const broadcaster = createStreamBroadcaster(this.inner.analyzeAssetStream(symbol), {
+      onComplete: (fullText) => {
+        if (fullText.trim().length > 0) writeCache(key, fullText);
+      },
+    });
+    // Overwrite any canceled predecessor; its identity-guarded cleanup will
+    // then no-op and leave this fresh entry in place.
+    inflightStreams.set(key, broadcaster);
+    const cleanup = () => {
+      if (inflightStreams.get(key) === broadcaster) inflightStreams.delete(key);
+    };
+    broadcaster.settled.then(cleanup, cleanup);
+
+    // A freshly created broadcaster is never canceled, so subscribe() is
+    // non-null; `?? []` only satisfies the type narrowing.
+    yield* broadcaster.subscribe() ?? [];
+  }
+}

--- a/src/adapters/cache/CachingAiAnalysisAdapter.ts
+++ b/src/adapters/cache/CachingAiAnalysisAdapter.ts
@@ -131,13 +131,24 @@ export class CachingAiAnalysisAdapter implements AiAnalysisPort {
     this.model = opts.model;
   }
 
-  /** Cache key: mode and model guard against cross-mode/stale-model bleed. */
-  private key(symbol: string): string {
-    return `${this.mode}:${this.model}:${symbol.toUpperCase()}`;
+  /**
+   * Canonical cache form for a symbol: trimmed + uppercased. Used for BOTH the
+   * cache key and the inner-adapter call so a cached result never depends on the
+   * first caller's casing/whitespace (e.g. `btc`, `BTC`, and ` BTC ` all map to
+   * the same key AND drive the same upstream prompt).
+   */
+  private normalizeSymbol(symbol: string): string {
+    return symbol.trim().toUpperCase();
+  }
+
+  /** Cache key (symbol already normalized): mode and model guard against cross-mode/stale-model bleed. */
+  private key(normalizedSymbol: string): string {
+    return `${this.mode}:${this.model}:${normalizedSymbol}`;
   }
 
   async analyzeAsset(symbol: string): Promise<string> {
-    const key = this.key(symbol);
+    const normalized = this.normalizeSymbol(symbol);
+    const key = this.key(normalized);
 
     const cached = readFresh(key);
     if (cached !== undefined) return cached;
@@ -145,7 +156,7 @@ export class CachingAiAnalysisAdapter implements AiAnalysisPort {
     const existing = inflightTexts.get(key);
     if (existing) return existing;
 
-    const promise = this.inner.analyzeAsset(symbol).then((text) => {
+    const promise = this.inner.analyzeAsset(normalized).then((text) => {
       if (text.trim().length > 0) writeCache(key, text);
       return text;
     });
@@ -161,7 +172,8 @@ export class CachingAiAnalysisAdapter implements AiAnalysisPort {
   }
 
   async *analyzeAssetStream(symbol: string): AsyncIterable<string> {
-    const key = this.key(symbol);
+    const normalized = this.normalizeSymbol(symbol);
+    const key = this.key(normalized);
 
     const cached = readFresh(key);
     if (cached !== undefined) {
@@ -179,7 +191,7 @@ export class CachingAiAnalysisAdapter implements AiAnalysisPort {
       return;
     }
 
-    const broadcaster = createStreamBroadcaster(this.inner.analyzeAssetStream(symbol), {
+    const broadcaster = createStreamBroadcaster(this.inner.analyzeAssetStream(normalized), {
       onComplete: (fullText) => {
         if (fullText.trim().length > 0) writeCache(key, fullText);
       },

--- a/src/adapters/cache/__tests__/CachingAiAnalysisAdapter.test.ts
+++ b/src/adapters/cache/__tests__/CachingAiAnalysisAdapter.test.ts
@@ -1,0 +1,240 @@
+/** @jest-environment node */
+import {
+  CachingAiAnalysisAdapter,
+  resetAiAnalysisCache,
+} from '@/adapters/cache/CachingAiAnalysisAdapter';
+import { AI_ANALYSIS_CACHE_MAX_ENTRIES, AI_ANALYSIS_CACHE_TTL_S } from '@/lib/config';
+import type { AiAnalysisPort } from '@/ports/AiAnalysisPort';
+
+async function collect(stream: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const chunk of stream) out.push(chunk);
+  return out;
+}
+
+async function* gen(chunks: string[]): AsyncGenerator<string> {
+  for (const c of chunks) {
+    await Promise.resolve();
+    yield c;
+  }
+}
+
+async function* genThenThrow(chunks: string[], err: unknown): AsyncGenerator<string> {
+  for (const c of chunks) {
+    await Promise.resolve();
+    yield c;
+  }
+  throw err;
+}
+
+function makeInner(): jest.Mocked<AiAnalysisPort> {
+  return {
+    analyzeAsset: jest.fn(),
+    analyzeAssetStream: jest.fn(),
+  };
+}
+
+const OPTS = { mode: 'live' as const, model: 'gpt-5.5' };
+
+describe('CachingAiAnalysisAdapter', () => {
+  beforeEach(() => {
+    resetAiAnalysisCache();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('analyzeAssetStream', () => {
+    it('re-emits a cache hit as a multi-chunk paced stream without calling the model again', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream.mockReturnValue(gen(['The ', 'quick ', 'brown ', 'fox ', 'jumps']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      const first = await collect(adapter.analyzeAssetStream('BTC'));
+      expect(first.join('')).toBe('The quick brown fox jumps');
+
+      const second = await collect(adapter.analyzeAssetStream('BTC'));
+      expect(inner.analyzeAssetStream).toHaveBeenCalledTimes(1);
+      expect(second.length).toBeGreaterThan(1);
+      expect(second.join('')).toBe('The quick brown fox jumps');
+    });
+
+    it('shares ONE upstream call across concurrent same-key requests', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream.mockReturnValue(gen(['a', 'b', 'c']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      const [r1, r2] = await Promise.all([
+        collect(adapter.analyzeAssetStream('BTC')),
+        collect(adapter.analyzeAssetStream('BTC')),
+      ]);
+
+      expect(inner.analyzeAssetStream).toHaveBeenCalledTimes(1);
+      expect(r1.join('')).toBe('abc');
+      expect(r2.join('')).toBe('abc');
+    });
+
+    it('does not cache a mid-stream error and re-calls the model on the next request', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream
+        .mockReturnValueOnce(genThenThrow(['part', 'ial'], new Error('mid')))
+        .mockReturnValueOnce(gen(['fresh']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await expect(collect(adapter.analyzeAssetStream('BTC'))).rejects.toThrow('mid');
+
+      const second = await collect(adapter.analyzeAssetStream('BTC'));
+      expect(second.join('')).toBe('fresh');
+      expect(inner.analyzeAssetStream).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache an empty result', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream
+        .mockReturnValueOnce(gen(['   ']))
+        .mockReturnValueOnce(gen(['real analysis']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await collect(adapter.analyzeAssetStream('BTC'));
+      const second = await collect(adapter.analyzeAssetStream('BTC'));
+
+      expect(inner.analyzeAssetStream).toHaveBeenCalledTimes(2);
+      expect(second.join('')).toBe('real analysis');
+    });
+  });
+
+  describe('analyzeAsset', () => {
+    it('caches a successful result and serves repeats without re-calling the model', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset.mockResolvedValue('analysis text');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      expect(await adapter.analyzeAsset('BTC')).toBe('analysis text');
+      expect(await adapter.analyzeAsset('BTC')).toBe('analysis text');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a rejected result', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('ok');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await expect(adapter.analyzeAsset('BTC')).rejects.toThrow('boom');
+      expect(await adapter.analyzeAsset('BTC')).toBe('ok');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache an empty result', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset.mockResolvedValueOnce('  ').mockResolvedValueOnce('real');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      expect(await adapter.analyzeAsset('BTC')).toBe('  ');
+      expect(await adapter.analyzeAsset('BTC')).toBe('real');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-calls the model after the TTL expires', async () => {
+      jest.useFakeTimers();
+      const inner = makeInner();
+      inner.analyzeAsset.mockResolvedValue('analysis text');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await adapter.analyzeAsset('BTC');
+      await adapter.analyzeAsset('BTC');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(AI_ANALYSIS_CACHE_TTL_S * 1000 + 1);
+
+      await adapter.analyzeAsset('BTC');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cache key', () => {
+    it('keys mock and live modes separately', async () => {
+      const liveInner = makeInner();
+      liveInner.analyzeAsset.mockResolvedValue('LIVE');
+      const mockInner = makeInner();
+      mockInner.analyzeAsset.mockResolvedValue('MOCK');
+
+      const live = new CachingAiAnalysisAdapter(liveInner, { mode: 'live', model: 'gpt-5.5' });
+      const mock = new CachingAiAnalysisAdapter(mockInner, { mode: 'mock', model: 'gpt-5.5' });
+
+      expect(await live.analyzeAsset('BTC')).toBe('LIVE');
+      // Same symbol, different mode → must NOT be served the live entry.
+      expect(await mock.analyzeAsset('BTC')).toBe('MOCK');
+      expect(mockInner.analyzeAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('keys distinct models separately', async () => {
+      const innerA = makeInner();
+      innerA.analyzeAsset.mockResolvedValue('A');
+      const innerB = makeInner();
+      innerB.analyzeAsset.mockResolvedValue('B');
+
+      const a = new CachingAiAnalysisAdapter(innerA, { mode: 'live', model: 'gpt-5.5' });
+      const b = new CachingAiAnalysisAdapter(innerB, { mode: 'live', model: 'gpt-5.4' });
+
+      expect(await a.analyzeAsset('BTC')).toBe('A');
+      expect(await b.analyzeAsset('BTC')).toBe('B');
+      expect(innerB.analyzeAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('normalizes symbol case so BTC and btc share an entry', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset.mockResolvedValue('shared');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await adapter.analyzeAsset('BTC');
+      await adapter.analyzeAsset('btc');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('evicts the least-recently-used entry over the cap and keeps refreshed entries', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset.mockImplementation((s: string) => Promise.resolve(`v-${s}`));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      // Fill the cache to capacity: S0 .. S{MAX-1}.
+      for (let i = 0; i < AI_ANALYSIS_CACHE_MAX_ENTRIES; i++) {
+        await adapter.analyzeAsset(`S${i}`);
+      }
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(AI_ANALYSIS_CACHE_MAX_ENTRIES);
+
+      // Touch S0 so it becomes most-recently-used (cache hit — no new call).
+      await adapter.analyzeAsset('S0');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(AI_ANALYSIS_CACHE_MAX_ENTRIES);
+
+      // One more distinct entry pushes over the cap, evicting S1 (now LRU).
+      await adapter.analyzeAsset('Sx');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(AI_ANALYSIS_CACHE_MAX_ENTRIES + 1);
+
+      // S0 was refreshed → survived → still a hit.
+      await adapter.analyzeAsset('S0');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(AI_ANALYSIS_CACHE_MAX_ENTRIES + 1);
+
+      // S1 was evicted → re-fetched.
+      await adapter.analyzeAsset('S1');
+      expect(inner.analyzeAsset).toHaveBeenCalledTimes(AI_ANALYSIS_CACHE_MAX_ENTRIES + 2);
+    });
+  });
+
+  describe('cross-method cache sharing', () => {
+    it('serves analyzeAsset from a value cached by a completed stream', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream.mockReturnValue(gen(['Hel', 'lo']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await collect(adapter.analyzeAssetStream('BTC'));
+
+      expect(await adapter.analyzeAsset('BTC')).toBe('Hello');
+      expect(inner.analyzeAsset).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/adapters/cache/__tests__/CachingAiAnalysisAdapter.test.ts
+++ b/src/adapters/cache/__tests__/CachingAiAnalysisAdapter.test.ts
@@ -184,14 +184,34 @@ describe('CachingAiAnalysisAdapter', () => {
       expect(innerB.analyzeAsset).toHaveBeenCalledTimes(1);
     });
 
-    it('normalizes symbol case so BTC and btc share an entry', async () => {
+    it('normalizes symbol case and whitespace so BTC, btc and " btc " share an entry', async () => {
       const inner = makeInner();
       inner.analyzeAsset.mockResolvedValue('shared');
       const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
 
       await adapter.analyzeAsset('BTC');
       await adapter.analyzeAsset('btc');
+      await adapter.analyzeAsset(' btc ');
       expect(inner.analyzeAsset).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the normalized (trimmed + uppercased) symbol to the inner adapter', async () => {
+      const inner = makeInner();
+      inner.analyzeAsset.mockResolvedValue('text');
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await adapter.analyzeAsset(' btc ');
+      // The cached content must not depend on the first caller's casing/whitespace.
+      expect(inner.analyzeAsset).toHaveBeenCalledWith('BTC');
+    });
+
+    it('passes the normalized symbol to the inner stream adapter', async () => {
+      const inner = makeInner();
+      inner.analyzeAssetStream.mockReturnValue(gen(['ok']));
+      const adapter = new CachingAiAnalysisAdapter(inner, OPTS);
+
+      await collect(adapter.analyzeAssetStream(' eth '));
+      expect(inner.analyzeAssetStream).toHaveBeenCalledWith('ETH');
     });
   });
 

--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -6,9 +6,11 @@ import { MockMarketDataAdapter } from '@/adapters/mock/MockMarketDataAdapter';
 import { MockTradingActivityAdapter } from '@/adapters/mock/MockTradingActivityAdapter';
 import { OpenAiAnalysisAdapter } from '@/adapters/openai/OpenAiAnalysisAdapter';
 import { MockAiAnalysisAdapter } from '@/adapters/mock/MockAiAnalysisAdapter';
+import { CachingAiAnalysisAdapter } from '@/adapters/cache/CachingAiAnalysisAdapter';
 import { NewsAdapter } from '@/adapters/news/NewsAdapter';
 import { MockNewsAdapter } from '@/adapters/news/MockNewsAdapter';
 import { getEnv } from '@/lib/env';
+import { AI_LLM_MODEL } from '@/lib/config';
 import type { AiAnalysisMode } from '@/lib/aiAnalysisMode';
 
 import type { CoinCapPort } from '@/ports/CoinCapPort';
@@ -42,12 +44,21 @@ export function getAiAnalysisDeps(mode: AiAnalysisMode): Promise<{ ai: AiAnalysi
   if (cached) return cached;
 
   const init = (async () => {
-    if (mode === 'mock') {
-      return { ai: new MockAiAnalysisAdapter() as AiAnalysisPort };
-    }
     const env = getEnv();
+    // Treat a blank OPENAI_MODEL as unset, matching the OpenAI adapter, so the
+    // cache key tracks the model that actually answers the request.
+    const model = env.OPENAI_MODEL?.trim() || AI_LLM_MODEL;
+
+    // The caching decorator wraps both modes (keyed separately by mode + model)
+    // so duplicate/concurrent requests are deduped and replayed identically
+    // whether running live or mock. The route and use case stay unchanged.
+    if (mode === 'mock') {
+      const inner = new MockAiAnalysisAdapter();
+      return { ai: new CachingAiAnalysisAdapter(inner, { mode, model }) as AiAnalysisPort };
+    }
     const news = env.NEWS_API_KEY ? new NewsAdapter() : new MockNewsAdapter();
-    return { ai: new OpenAiAnalysisAdapter({ binance, news }) as AiAnalysisPort };
+    const inner = new OpenAiAnalysisAdapter({ binance, news });
+    return { ai: new CachingAiAnalysisAdapter(inner, { mode, model }) as AiAnalysisPort };
   })();
 
   // Reset the cached promise on failure so a later call can retry. The adapter

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -39,3 +39,20 @@ export const AI_LLM_REASONING_EFFORT = "low";
 // AI_ANALYSIS_TIMEOUT_MS env var; the adapter falls back to this default when
 // the env var is unset or not a positive integer.
 export const AI_LLM_TIMEOUT_MS = 30_000;
+
+// -- AI analysis cache (CachingAiAnalysisAdapter) -----------------------------
+// TTL for a stored analysis. Within this window a repeat request for the same
+// `mode:model:SYMBOL` is served from the in-memory cache as a paced stream
+// instead of calling the model again. ~5 minutes balances freshness against the
+// cost/latency saving on repeat views.
+export const AI_ANALYSIS_CACHE_TTL_S = 300;
+// Soft cap on distinct cached entries. The cache is a module-level Map with LRU
+// eviction (least-recently-used dropped first), bounding memory on a long-lived
+// instance. Small because the asset whitelist is small.
+export const AI_ANALYSIS_CACHE_MAX_ENTRIES = 100;
+// Paced cache-hit replay: target total wall-time for re-emitting stored text as
+// a "typed" stream, so a cache hit feels like a fresh generation. Kept inside
+// the ~0.6–1.2s band; the per-chunk floor stops a short analysis from replaying
+// in one instant burst.
+export const AI_ANALYSIS_REPLAY_TOTAL_MS = 900;
+export const AI_ANALYSIS_REPLAY_MIN_CHUNK_MS = 15;

--- a/src/lib/http/__tests__/streamBroadcaster.test.ts
+++ b/src/lib/http/__tests__/streamBroadcaster.test.ts
@@ -1,0 +1,190 @@
+/** @jest-environment node */
+import { createStreamBroadcaster } from '@/lib/http/streamBroadcaster';
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+async function collect(stream: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const chunk of stream) out.push(chunk);
+  return out;
+}
+
+/**
+ * A hand-driven async source: chunks/end/error are delivered on demand so tests
+ * control exactly when the source advances, and `.return()` resolves any pending
+ * `.next()` the way a real async generator does.
+ */
+function manualSource() {
+  let iterCount = 0;
+  let returned = false;
+  type Item =
+    | { type: 'next'; value: string }
+    | { type: 'end' }
+    | { type: 'error'; error: unknown };
+  const queued: Item[] = [];
+  let pending: { resolve: (r: IteratorResult<string>) => void; reject: (e: unknown) => void } | null = null;
+
+  function settle(item: Item, resolve: (r: IteratorResult<string>) => void, reject: (e: unknown) => void) {
+    if (item.type === 'next') resolve({ done: false, value: item.value });
+    else if (item.type === 'end') resolve({ done: true, value: undefined });
+    else reject(item.error);
+  }
+
+  function deliver(item: Item) {
+    if (pending) {
+      const p = pending;
+      pending = null;
+      settle(item, p.resolve, p.reject);
+    } else {
+      queued.push(item);
+    }
+  }
+
+  const iterator: AsyncIterator<string> = {
+    next() {
+      if (queued.length) {
+        return new Promise((resolve, reject) => settle(queued.shift()!, resolve, reject));
+      }
+      return new Promise((resolve, reject) => {
+        pending = { resolve, reject };
+      });
+    },
+    return() {
+      returned = true;
+      if (pending) {
+        const p = pending;
+        pending = null;
+        p.resolve({ done: true, value: undefined });
+      }
+      return Promise.resolve({ done: true, value: undefined });
+    },
+  };
+
+  return {
+    source: {
+      [Symbol.asyncIterator]() {
+        iterCount++;
+        return iterator;
+      },
+    } as AsyncIterable<string>,
+    push: (value: string) => deliver({ type: 'next', value }),
+    end: () => deliver({ type: 'end' }),
+    error: (error: unknown) => deliver({ type: 'error', error }),
+    isReturned: () => returned,
+    iterCount: () => iterCount,
+  };
+}
+
+describe('createStreamBroadcaster', () => {
+  it('drives the source once and fans every chunk out to all subscribers', async () => {
+    const src = manualSource();
+    const bc = createStreamBroadcaster(src.source);
+
+    const r1 = collect(bc.subscribe()!);
+    const r2 = collect(bc.subscribe()!);
+
+    src.push('a');
+    src.push('b');
+    src.end();
+
+    expect(await r1).toEqual(['a', 'b']);
+    expect(await r2).toEqual(['a', 'b']);
+    // Source iterated exactly once despite two consumers.
+    expect(src.iterCount()).toBe(1);
+  });
+
+  it('replays the buffered prefix to a late subscriber, then live chunks', async () => {
+    const src = manualSource();
+    const bc = createStreamBroadcaster(src.source);
+
+    const out1: string[] = [];
+    const reader1 = (async () => {
+      for await (const c of bc.subscribe()!) out1.push(c);
+    })();
+
+    src.push('a');
+    await tick();
+    src.push('b');
+    await tick();
+
+    // Late subscriber joins after 'a','b' are buffered.
+    const out2: string[] = [];
+    const reader2 = (async () => {
+      for await (const c of bc.subscribe()!) out2.push(c);
+    })();
+    await tick();
+
+    src.push('c');
+    src.end();
+
+    await Promise.all([reader1, reader2]);
+    expect(out1).toEqual(['a', 'b', 'c']);
+    // Late subscriber replays the prefix then receives the remaining live chunk.
+    expect(out2).toEqual(['a', 'b', 'c']);
+  });
+
+  it('propagates a mid-stream error to every subscriber and does not complete', async () => {
+    const src = manualSource();
+    const onComplete = jest.fn();
+    const bc = createStreamBroadcaster(src.source, { onComplete });
+
+    const r1 = collect(bc.subscribe()!);
+    const r2 = collect(bc.subscribe()!);
+
+    src.push('a');
+    src.error(new Error('boom'));
+
+    await expect(r1).rejects.toThrow('boom');
+    await expect(r2).rejects.toThrow('boom');
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('invokes onComplete once with the full text on natural completion', async () => {
+    const src = manualSource();
+    const onComplete = jest.fn();
+    const bc = createStreamBroadcaster(src.source, { onComplete });
+
+    const reader = collect(bc.subscribe()!);
+    src.push('Hello, ');
+    src.push('world');
+    src.end();
+    await reader;
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('Hello, world');
+  });
+
+  it('cancels the source only when the last consumer detaches', async () => {
+    const src = manualSource();
+    const bc = createStreamBroadcaster(src.source);
+
+    const it1 = bc.subscribe()![Symbol.asyncIterator]();
+    const it2 = bc.subscribe()![Symbol.asyncIterator]();
+
+    src.push('a');
+    await it1.next();
+    await it2.next();
+
+    // First consumer leaves — source must stay alive for the second.
+    await it1.return!();
+    expect(src.isReturned()).toBe(false);
+
+    // Last consumer leaves — now the source is canceled.
+    await it2.return!();
+    expect(src.isReturned()).toBe(true);
+
+    // A canceled broadcaster refuses new joiners.
+    expect(bc.subscribe()).toBeNull();
+  });
+
+  it('refuses new joiners after the source has errored', async () => {
+    const src = manualSource();
+    const bc = createStreamBroadcaster(src.source);
+
+    const r1 = collect(bc.subscribe()!);
+    src.error(new Error('nope'));
+    await expect(r1).rejects.toThrow('nope');
+
+    expect(bc.subscribe()).toBeNull();
+  });
+});

--- a/src/lib/http/__tests__/streamBroadcaster.test.ts
+++ b/src/lib/http/__tests__/streamBroadcaster.test.ts
@@ -177,6 +177,27 @@ describe('createStreamBroadcaster', () => {
     expect(bc.subscribe()).toBeNull();
   });
 
+  it('honors return() and cancels a silent source while parked awaiting the next chunk', async () => {
+    const src = manualSource();
+    const bc = createStreamBroadcaster(src.source);
+
+    const it = bc.subscribe()![Symbol.asyncIterator]();
+    src.push('a');
+    await it.next(); // receives 'a'
+
+    // Pull again with no further chunks: the generator parks on the internal
+    // wait while the source stays silent.
+    const pending = it.next();
+    await tick();
+
+    // Disconnect while parked. The periodic wake must let return() run the
+    // generator's finally so the last-consumer cancellation fires.
+    const ret = it.return!();
+    await Promise.all([ret, pending.catch(() => undefined)]);
+
+    expect(src.isReturned()).toBe(true);
+  });
+
   it('refuses new joiners after the source has errored', async () => {
     const src = manualSource();
     const bc = createStreamBroadcaster(src.source);

--- a/src/lib/http/streamBroadcaster.ts
+++ b/src/lib/http/streamBroadcaster.ts
@@ -8,19 +8,24 @@
  * requests share a single upstream call.
  *
  * Lifecycle:
- * - The source starts on the first `subscribe()` pull, not when the broadcaster
- *   is created (so creating one is cheap and side-effect free).
+ * - The source starts on the first `subscribe()`, not when the broadcaster is
+ *   created (so creating one is cheap and side-effect free).
  * - Consumers are ref-counted. The source is canceled (its iterator `.return()`
  *   is called) only when the last consumer detaches *before* the source has
  *   finished — a single consumer disconnecting never kills a stream others are
  *   still reading. The port takes no abort signal, so iterator `.return()` is
  *   the cancellation mechanism.
+ * - Each subscriber is a hand-rolled async iterator whose `return()` detaches
+ *   the consumer (decrement + maybe-cancel) SYNCHRONOUSLY. A native async
+ *   generator parked at `await` cannot run its `finally` until the awaited
+ *   promise settles, so a queued `.return()` on a silent source would never
+ *   release the slot; an explicit `return()` method avoids that trap.
  * - `onComplete` fires once, only on natural completion of the source (not on
  *   error, not on cancellation), with the full concatenated text. This is the
  *   single place a caller should persist a successful result.
- * - A source error is surfaced to every subscriber (each `subscribe()` loop
- *   rethrows after draining what it had buffered), so callers never treat a
- *   failed run as success.
+ * - A source error is surfaced to every subscriber (each `next()` rethrows
+ *   after draining what it had buffered), so callers never treat a failed run
+ *   as success.
  */
 
 export interface StreamBroadcaster {
@@ -32,10 +37,10 @@ export interface StreamBroadcaster {
    * rather than replay a truncated buffer or a cached failure. (Consumers that
    * are already attached when the error lands still receive the error.)
    *
-   * The returned iterable reserves a consumer slot synchronously; the caller
-   * MUST drive it (at least one `.next()`, e.g. via `yield*` or `for await`) so
-   * the slot is released in its `finally`. Abandoning it unpulled leaks the
-   * slot and pins the source open.
+   * Reserves a consumer slot synchronously. The slot is released when the
+   * returned iterator completes, throws, or its `return()` is called (e.g. a
+   * `for await` that breaks, or the route canceling its stream on client
+   * disconnect).
    */
   subscribe(): AsyncIterable<string> | null;
   /** Resolves when the source settles (completed, errored, or canceled). */
@@ -52,7 +57,6 @@ export function createStreamBroadcaster(
   callbacks: BroadcasterCallbacks = {},
 ): StreamBroadcaster {
   const buffer: string[] = [];
-  let waiters: Array<() => void> = [];
   let done = false;
   let errored = false;
   let error: unknown;
@@ -61,15 +65,27 @@ export function createStreamBroadcaster(
   let consumers = 0;
   let sourceIterator: AsyncIterator<string> | undefined;
 
-  let resolveSettled: () => void;
+  // A single re-armable promise all parked subscribers await; `notify()` resolves
+  // the current one and arms the next. (Assigned synchronously in the executors
+  // below, so the definite-assignment assertions are safe.)
+  let triggerWake!: () => void;
+  let wakeup = new Promise<void>((resolve) => {
+    triggerWake = resolve;
+  });
+
+  let resolveSettled!: () => void;
   const settled = new Promise<void>((resolve) => {
     resolveSettled = resolve;
   });
 
+  // Wake every parked subscriber (new chunk, terminal state, or a detach so a
+  // parked next() can resolve to done), then arm a fresh promise for the next.
   function notify(): void {
-    const pending = waiters;
-    waiters = [];
-    for (const resolve of pending) resolve();
+    const resolve = triggerWake;
+    wakeup = new Promise<void>((next) => {
+      triggerWake = next;
+    });
+    resolve();
   }
 
   async function pump(): Promise<void> {
@@ -124,26 +140,50 @@ export function createStreamBroadcaster(
     // subscriber replays the buffer and then sees the terminal state.)
     consumers++;
     startIfNeeded();
-    return iterate();
-  }
 
-  async function* iterate(): AsyncIterable<string> {
     let index = 0;
-    try {
-      while (true) {
-        while (index < buffer.length) {
-          yield buffer[index++];
-        }
-        // Buffer fully drained: only now surface terminal state, so a late
-        // subscriber still replays every buffered chunk before the end/error.
-        if (errored) throw error;
-        if (done) return;
-        await new Promise<void>((resolve) => waiters.push(resolve));
-      }
-    } finally {
+    let detached = false;
+
+    // Release this consumer's slot exactly once. Called from return() (caller
+    // disconnect) and from next() on terminal state. Crucially this runs
+    // synchronously in return(), so it does not depend on a parked next()
+    // completing — which a native generator's finally could not guarantee.
+    function detach(): void {
+      if (detached) return;
+      detached = true;
       consumers--;
       maybeCancel();
+      // Wake any parked next() so it can observe `detached`/terminal and resolve.
+      notify();
     }
+
+    const iterator: AsyncIterator<string> = {
+      async next(): Promise<IteratorResult<string>> {
+        while (true) {
+          if (index < buffer.length) {
+            return { done: false, value: buffer[index++] };
+          }
+          // Buffer fully drained: a late subscriber has now replayed every
+          // buffered chunk before seeing the terminal state.
+          if (detached) return { done: true, value: undefined };
+          if (errored) {
+            detach();
+            throw error;
+          }
+          if (done) {
+            detach();
+            return { done: true, value: undefined };
+          }
+          await wakeup;
+        }
+      },
+      async return(): Promise<IteratorResult<string>> {
+        detach();
+        return { done: true, value: undefined };
+      },
+    };
+
+    return { [Symbol.asyncIterator]: () => iterator };
   }
 
   return { subscribe, settled };

--- a/src/lib/http/streamBroadcaster.ts
+++ b/src/lib/http/streamBroadcaster.ts
@@ -1,0 +1,150 @@
+/**
+ * Fan-out for a single async-iterable source.
+ *
+ * A broadcaster drives ONE source `AsyncIterable<string>` (e.g. one upstream
+ * model stream) and lets many consumers each replay the buffered prefix and
+ * then subscribe to live chunks. The source is pulled exactly once regardless
+ * of how many consumers attach — this is what lets concurrent identical
+ * requests share a single upstream call.
+ *
+ * Lifecycle:
+ * - The source starts on the first `subscribe()` pull, not when the broadcaster
+ *   is created (so creating one is cheap and side-effect free).
+ * - Consumers are ref-counted. The source is canceled (its iterator `.return()`
+ *   is called) only when the last consumer detaches *before* the source has
+ *   finished — a single consumer disconnecting never kills a stream others are
+ *   still reading. The port takes no abort signal, so iterator `.return()` is
+ *   the cancellation mechanism.
+ * - `onComplete` fires once, only on natural completion of the source (not on
+ *   error, not on cancellation), with the full concatenated text. This is the
+ *   single place a caller should persist a successful result.
+ * - A source error is surfaced to every subscriber (each `subscribe()` loop
+ *   rethrows after draining what it had buffered), so callers never treat a
+ *   failed run as success.
+ */
+
+export interface StreamBroadcaster {
+  /**
+   * Replay the buffered prefix, then yield live chunks until done or error.
+   * Returns `null` if the broadcaster is no longer joinable — canceled (its
+   * last consumer detached and the source was stopped) or errored (the source
+   * already failed). In both cases the caller must start a fresh upstream
+   * rather than replay a truncated buffer or a cached failure. (Consumers that
+   * are already attached when the error lands still receive the error.)
+   *
+   * The returned iterable reserves a consumer slot synchronously; the caller
+   * MUST drive it (at least one `.next()`, e.g. via `yield*` or `for await`) so
+   * the slot is released in its `finally`. Abandoning it unpulled leaks the
+   * slot and pins the source open.
+   */
+  subscribe(): AsyncIterable<string> | null;
+  /** Resolves when the source settles (completed, errored, or canceled). */
+  readonly settled: Promise<void>;
+}
+
+export interface BroadcasterCallbacks {
+  /** Called once on successful, natural completion with the full text. */
+  onComplete?: (fullText: string) => void;
+}
+
+export function createStreamBroadcaster(
+  source: AsyncIterable<string>,
+  callbacks: BroadcasterCallbacks = {},
+): StreamBroadcaster {
+  const buffer: string[] = [];
+  let waiters: Array<() => void> = [];
+  let done = false;
+  let errored = false;
+  let error: unknown;
+  let started = false;
+  let canceled = false;
+  let consumers = 0;
+  let sourceIterator: AsyncIterator<string> | undefined;
+
+  let resolveSettled: () => void;
+  const settled = new Promise<void>((resolve) => {
+    resolveSettled = resolve;
+  });
+
+  function notify(): void {
+    const pending = waiters;
+    waiters = [];
+    for (const resolve of pending) resolve();
+  }
+
+  async function pump(): Promise<void> {
+    sourceIterator = source[Symbol.asyncIterator]();
+    try {
+      while (true) {
+        const next = await sourceIterator.next();
+        // A consumer may have detached and canceled us while we awaited; drop
+        // the in-flight chunk and stop rather than buffering past cancellation.
+        if (canceled) break;
+        if (next.done) {
+          callbacks.onComplete?.(buffer.join(''));
+          break;
+        }
+        buffer.push(next.value);
+        notify();
+      }
+    } catch (err) {
+      errored = true;
+      error = err;
+    } finally {
+      done = true;
+      notify();
+      resolveSettled();
+    }
+  }
+
+  function startIfNeeded(): void {
+    if (started) return;
+    started = true;
+    void pump();
+  }
+
+  function maybeCancel(): void {
+    if (consumers === 0 && started && !done && !canceled) {
+      canceled = true;
+      // Best-effort: stop the source from doing further work. Errors from
+      // return() (e.g. a generator already settling) are irrelevant here.
+      void Promise.resolve(sourceIterator?.return?.()).catch(() => {});
+    }
+  }
+
+  function subscribe(): AsyncIterable<string> | null {
+    // A canceled or already-errored broadcaster is not joinable: a new caller
+    // must start a fresh upstream instead of replaying a truncated buffer or
+    // re-throwing a failure (errors are never cached).
+    if (canceled || errored) return null;
+    // Reserve the consumer slot synchronously, at subscribe() time rather than
+    // on the first pull, so a just-subscribed consumer that has not pulled yet
+    // still prevents a concurrently-detaching consumer from canceling the
+    // source. (A completed/errored broadcaster can still be joined — a late
+    // subscriber replays the buffer and then sees the terminal state.)
+    consumers++;
+    startIfNeeded();
+    return iterate();
+  }
+
+  async function* iterate(): AsyncIterable<string> {
+    let index = 0;
+    try {
+      while (true) {
+        while (index < buffer.length) {
+          yield buffer[index++];
+        }
+        // Buffer fully drained: only now surface terminal state, so a late
+        // subscriber still replays every buffered chunk before the end/error.
+        if (errored) throw error;
+        if (done) return;
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+    } finally {
+      consumers--;
+      maybeCancel();
+    }
+  }
+
+  return { subscribe, settled };
+}


### PR DESCRIPTION
## Summary

Implements task **NEU-21**: Global TTL cache for AI analysis (dedup + simulated cache-hit streaming).

A stream-aware caching decorator over `AiAnalysisPort` that serves duplicate requests from a short in-memory TTL cache and shares concurrent in-flight computations — while every path (fresh, deduped, cached) streams to the client as "typed" text so the card's UX is identical whether freshly generated or served from cache.

**Type:** feat
**Complexity:** M

## What was done

- New `src/adapters/cache/CachingAiAnalysisAdapter.ts` — implements `AiAnalysisPort`, wrapping the inner adapter. Module-level TTL `Map` with lazy expiry + small LRU cap, keyed `mode:model:SYMBOL`. Cache hit re-emits stored text as a paced "typed" stream; miss forwards live chunks while accumulating and caches only successful, non-empty completions. `analyzeAsset` shares the same cache.
- New `src/lib/http/streamBroadcaster.ts` — single-source fan-out: buffered-prefix + live-subscribe so concurrent same-key requests share ONE upstream model call. Ref-counts consumers and cancels the source (iterator `.return()`) only when the last consumer detaches; refuses new joiners once canceled/errored; propagates errors to every subscriber.
- `src/lib/config.ts` — `AI_ANALYSIS_CACHE_TTL_S` (300s), `AI_ANALYSIS_CACHE_MAX_ENTRIES` (100), and paced-replay cadence (`AI_ANALYSIS_REPLAY_TOTAL_MS`, `AI_ANALYSIS_REPLAY_MIN_CHUNK_MS`).
- `src/compositionRoot.ts` — wires the decorator over both the mock and live adapters in `getAiAnalysisDeps`; route and use case unchanged.
- Unit tests for the broadcaster (6) and decorator (13): cache-hit replay, concurrent dedup (one upstream call), TTL expiry, errors/empty not cached, mode/model/symbol keying, LRU eviction, cross-method sharing. Patch line coverage 100% on both new files.

## Done When

- `pnpm preflight` exits 0 (typecheck + lint + all tests green).
- Decorator tests prove: multi-chunk cache-hit replay, exactly one upstream call for concurrent same-key requests, TTL expiry forces a fresh call, errors are not cached.
- `app/api/ai-analysis/[symbol]/route.ts`, `lib/data/aiAnalysisServer.ts`, and `src/usecases/getAiAnalysis.ts` have no diff (decorator wired only in the composition root).
